### PR TITLE
Make scrollbar disappear if it is not neccessary

### DIFF
--- a/bepasty/static/app/css/style.css
+++ b/bepasty/static/app/css/style.css
@@ -12,7 +12,7 @@ body {
 }
 
 #footer {
-    height: 2em;
+    height: 30px;
     position: relative;
 }
 


### PR DESCRIPTION
On the main page always appeared a scroll bar, because the content was about 1px too high. this fixes it.
