### PR TITLE
fixes #108 - set fixed width to line column

### DIFF
--- a/bepasty/static/app/css/style.css
+++ b/bepasty/static/app/css/style.css
@@ -113,3 +113,8 @@ table.highlighttable {
     padding-left: 0;
     padding-right: 0;
 }
+
+/* Set minimal width and let the contents push the block width */
+.linenos {
+    width: 1px;
+}


### PR DESCRIPTION
The width is set to 1px. That makes the contents of the block push as much as they need. For example, the line column has 10000 lines, then it's width will expand and push the `<td>` to wrap the long line numbers.
