### PR TITLE
docs/install-tutorial.rst: add proxy_set_header

### DIFF
--- a/docs/source/install-tutorial.rst
+++ b/docs/source/install-tutorial.rst
@@ -93,6 +93,7 @@ A nginx configuration i.e. in ``/etc/nginx/conf.d/bepasty.conf``:
     client_max_body_size 32M;
 
     location / {
+        proxy_set_header Host $http_host;
         proxy_pass http://pasty_server;
     }
 


### PR DESCRIPTION
proxy_set_header Host is required so flask knows the hostname it should respond to when being requested via a socket.
not doing so results in redirects to \`localhost\` when trying add new pastes