### PR TITLE
prevent int cast on empty string

### DIFF
--- a/bepasty/views/upload.py
+++ b/bepasty/views/upload.py
@@ -72,7 +72,7 @@ class UploadNewView(MethodView):
         data_type = data['type']
 
         # set max lifetime
-        maxlife_value = int(data['maxlife_value'])
+        maxlife_value = int(request.form.get('maxlife-value', 1))
         maxlife_unit = data['maxlife_unit'].upper()
         maxtime = time_unit_to_sec(maxlife_value, maxlife_unit)
         maxlife_timestamp = int(time.time()) + maxtime if maxtime > 0 else maxtime


### PR DESCRIPTION
Fixes file upload for me:

```
[2018-01-05 09:49:44,536] ERROR in app: Exception on /+upload [POST]
Traceback (most recent call last):
  File "*hidden*/env/lib/python3.5/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "*hidden*/env/lib/python3.5/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "*hidden*/env/lib/python3.5/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "*hidden*/env/lib/python3.5/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "*hidden*/env/lib/python3.5/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "*hidden*/env/lib/python3.5/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "*hidden*/env/lib/python3.5/site-packages/flask/views.py", line 84, in view
    return self.dispatch_request(*args, **kwargs)
  File "*hidden*/env/lib/python3.5/site-packages/flask/views.py", line 149, in dispatch_request
    return meth(*args, **kwargs)
  File "./bepasty/views/upload.py", line 56, in post
    maxlife_value = int(request.form.get('maxlife-value', 1))
ValueError: invalid literal for int() with base 10: ''
```
