### PR TITLE
use names from bepasty.constants instead of hardcoded strings

### DIFF
--- a/src/bepasty/apis/rest.py
+++ b/src/bepasty/apis/rest.py
@@ -7,6 +7,8 @@ from . import blueprint
 from flask import Response, make_response, url_for, jsonify, stream_with_context
 from flask.views import MethodView
 
+from ..constants import *  # noqa
+
 from ..utils.name import ItemName
 from ..utils.http import ContentRange, DownloadRange
 from ..utils.upload import Upload, background_compute_hash
@@ -101,7 +103,7 @@ class ItemUploadView(MethodView):
         # Check if file is completely uploaded and set meta
         if file_range.is_complete:
             Upload.meta_complete(item, '')
-            item.meta['size'] = item.data.size
+            item.meta[SIZE] = item.data.size
             item.close()
 
             background_compute_hash(current_app.storage, name)
@@ -159,9 +161,9 @@ class ItemDownloadView(MethodView):
                 return 'File not found', 404
             raise
 
-        if item.meta.get('locked'):
+        if item.meta.get():
             error = 'File Locked.'
-        elif not item.meta.get('complete'):
+        elif not item.meta.get(COMPLETE):
             error = 'Upload incomplete. Try again later.'
         else:
             error = None
@@ -190,9 +192,9 @@ class ItemDownloadView(MethodView):
 
         ret = Response(stream_with_context(stream(range_begin, range_end)))
         ret.headers['Content-Disposition'] = '{0}; filename="{1}"'.format(
-            self.content_disposition, item.meta['filename'])
+            self.content_disposition, item.meta[FILENAME])
         ret.headers['Content-Length'] = (range_end - range_begin) + 1
-        ret.headers['Content-Type'] = item.meta['type']  # 'application/octet-stream'
+        ret.headers['Content-Type'] = item.meta[TYPE]  # 'application/octet-stream'
         ret.status = '200'
         ret.headers['Content-Range'] = ('bytes %d-%d/%d' % (range_begin, range_end, item.data.size))
         return ret

--- a/src/bepasty/constants.py
+++ b/src/bepasty/constants.py
@@ -1,0 +1,10 @@
+FILENAME = 'filename'
+TYPE = 'type'
+LOCKED = 'locked'
+SIZE = 'size'
+COMPLETE = 'complete'
+HASH = 'hash'
+TIMESTAMP_UPLOAD = 'timestamp-upload'
+TIMESTAMP_DOWNLOAD = 'timestamp-download'
+TIMESTAMP_MAX_LIFE = 'timestamp-max-life'
+ID = 'id'  # storage name

--- a/src/bepasty/utils/date_funcs.py
+++ b/src/bepasty/utils/date_funcs.py
@@ -1,6 +1,8 @@
 import time
 from flask import current_app
 
+from ..constants import *  # noqa
+
 FOREVER = -1
 
 
@@ -29,7 +31,7 @@ def delete_if_lifetime_over(item, name):
     """
     :return: True if file was deleted
     """
-    if 0 < item.meta['timestamp-max-life'] < time.time():
+    if 0 < item.meta[TIMESTAMP_MAX_LIFE] < time.time():
         try:
             current_app.storage.remove(name)
         except (OSError, IOError) as e:

--- a/src/bepasty/utils/upload.py
+++ b/src/bepasty/utils/upload.py
@@ -7,6 +7,9 @@ from flask import abort, current_app
 from .name import ItemName
 from .decorators import threaded
 from .hashing import compute_hash, hash_new
+
+from ..constants import *  # noqa
+
 from ..utils.date_funcs import FOREVER
 
 # we limit to 250 characters as we do not want to accept arbitrarily long
@@ -63,21 +66,21 @@ class Upload(object):
     @classmethod
     def meta_new(cls, item, input_size, input_filename, input_type,
                  input_type_hint, storage_name, maxlife_stamp=FOREVER):
-        item.meta['filename'] = cls.filter_filename(input_filename,
-                                                    storage_name, input_type, input_type_hint)
-        item.meta['size'] = cls.filter_size(input_size)
-        item.meta['type'] = cls.filter_type(input_type, input_type_hint, input_filename)
-        item.meta['timestamp-upload'] = int(time.time())
-        item.meta['timestamp-download'] = 0
-        item.meta['locked'] = current_app.config['UPLOAD_LOCKED']
-        item.meta['complete'] = False
-        item.meta['hash'] = ''
-        item.meta['timestamp-max-life'] = maxlife_stamp
+        item.meta[FILENAME] = cls.filter_filename(input_filename,
+                                                  storage_name, input_type, input_type_hint)
+        item.meta[SIZE] = cls.filter_size(input_size)
+        item.meta[TYPE] = cls.filter_type(input_type, input_type_hint, input_filename)
+        item.meta[TIMESTAMP_UPLOAD] = int(time.time())
+        item.meta[TIMESTAMP_DOWNLOAD] = 0
+        item.meta[LOCKED] = current_app.config['UPLOAD_LOCKED']
+        item.meta[COMPLETE] = False
+        item.meta[HASH] = ''
+        item.meta[TIMESTAMP_MAX_LIFE] = maxlife_stamp
 
     @classmethod
     def meta_complete(cls, item, file_hash):
-        item.meta['complete'] = True
-        item.meta['hash'] = file_hash
+        item.meta[COMPLETE] = True
+        item.meta[HASH] = file_hash
 
     @staticmethod
     def data(item, f, size_input, offset=0):
@@ -125,6 +128,6 @@ def create_item(f, filename, size, content_type, content_type_hint,
 @threaded
 def background_compute_hash(storage, name):
     with storage.openwrite(name) as item:
-        size = item.meta['size']
+        size = item.meta[SIZE]
         file_hash = compute_hash(item.data, size)
-        item.meta['hash'] = file_hash
+        item.meta[HASH] = file_hash

--- a/src/bepasty/views/delete.py
+++ b/src/bepasty/views/delete.py
@@ -5,6 +5,9 @@ from flask.views import MethodView
 from werkzeug.exceptions import NotFound, Forbidden
 
 from . import blueprint
+
+from ..constants import *  # noqa
+
 from ..utils.permissions import *
 from ..utils.http import redirect_next_referrer
 
@@ -15,11 +18,11 @@ class DeleteView(MethodView):
             raise Forbidden()
         try:
             with current_app.storage.open(name) as item:
-                if not item.meta['complete'] and not may(ADMIN):
+                if not item.meta[COMPLETE] and not may(ADMIN):
                     error = 'Upload incomplete. Try again later.'
-                    return render_template('error.html', heading=item.meta['filename'], body=error), 409
+                    return render_template('error.html', heading=item.meta[FILENAME], body=error), 409
 
-                if item.meta['locked'] and not may(ADMIN):
+                if item.meta[LOCKED] and not may(ADMIN):
                     raise Forbidden()
 
             current_app.storage.remove(name)

--- a/src/bepasty/views/filelist.py
+++ b/src/bepasty/views/filelist.py
@@ -5,6 +5,9 @@ from flask.views import MethodView
 from werkzeug.exceptions import Forbidden
 
 from . import blueprint
+
+from ..constants import *  # noqa
+
 from ..utils.permissions import *
 from ..utils.date_funcs import delete_if_lifetime_over
 
@@ -12,7 +15,7 @@ from ..utils.date_funcs import delete_if_lifetime_over
 def file_infos(names=None):
     """
     iterates over storage files metadata.
-    note: we put the storage name into the metadata as 'id'
+    note: we put the storage name into the metadata as ID
 
     :param names: None means "all items"
                   otherwise give a list of storage item names
@@ -26,7 +29,7 @@ def file_infos(names=None):
                 meta = dict(item.meta)
                 if delete_if_lifetime_over(item, name):
                     continue
-                meta['id'] = name
+                meta[ID] = name
                 yield meta
         except (OSError, IOError) as e:
             if e.errno != errno.ENOENT:
@@ -37,7 +40,7 @@ class FileListView(MethodView):
     def get(self):
         if not may(LIST):
             raise Forbidden()
-        files = sorted(file_infos(), key=lambda f: f['timestamp-upload'], reverse=True)
+        files = sorted(file_infos(), key=lambda f: f[TIMESTAMP_UPLOAD], reverse=True)
         return render_template('filelist.html', files=files)
 
 

--- a/src/bepasty/views/setkv.py
+++ b/src/bepasty/views/setkv.py
@@ -9,6 +9,9 @@ from flask.views import MethodView
 from werkzeug.exceptions import NotFound, Forbidden
 
 from . import blueprint
+
+from ..constants import *  # noqa
+
 from ..utils.permissions import *
 from ..utils.http import redirect_next_referrer
 
@@ -26,12 +29,12 @@ class SetKeyValueView(MethodView):
             with current_app.storage.openwrite(name) as item:
                 if item.meta[self.KEY] == self.NEXT_VALUE:
                     error = '%s already is %r.' % (self.KEY, self.NEXT_VALUE)
-                elif not item.meta['complete']:
+                elif not item.meta[COMPLETE]:
                     error = 'Upload incomplete. Try again later.'
                 else:
                     error = None
                 if error:
-                    return render_template('error.html', heading=item.meta['filename'], body=error), 409
+                    return render_template('error.html', heading=item.meta[FILENAME], body=error), 409
                 item.meta[self.KEY] = self.NEXT_VALUE
             return redirect_next_referrer('bepasty.display', name=name)
 
@@ -43,13 +46,13 @@ class SetKeyValueView(MethodView):
 
 class LockView(SetKeyValueView):
     REQUIRED_PERMISSION = ADMIN
-    KEY = 'locked'
+    KEY = LOCKED
     NEXT_VALUE = True
 
 
 class UnlockView(SetKeyValueView):
     REQUIRED_PERMISSION = ADMIN
-    KEY = 'locked'
+    KEY = LOCKED
     NEXT_VALUE = False
 
 

--- a/src/bepasty/views/upload.py
+++ b/src/bepasty/views/upload.py
@@ -8,6 +8,8 @@ from flask.views import MethodView
 from werkzeug.exceptions import NotFound, Forbidden
 from werkzeug.urls import url_quote
 
+from ..constants import *  # noqa
+
 from ..utils.http import ContentRange, redirect_next
 from ..utils.name import ItemName
 from ..utils.upload import Upload, create_item, background_compute_hash
@@ -122,10 +124,10 @@ class UploadContinueView(MethodView):
 
             result = jsonify({'files': [{
                 'name': name,
-                'filename': item.meta['filename'],
-                'size': item.meta['size'],
+                'filename': item.meta[FILENAME],
+                'size': item.meta[SIZE],
                 'url': "{0}#{1}".format(url_for('bepasty.display', name=name),
-                                        item.meta['filename']),
+                                        item.meta[FILENAME]),
             }]})
 
         if is_complete and not file_hash:
@@ -146,7 +148,7 @@ class UploadAbortView(MethodView):
                 return 'No file found.', 404
             raise
 
-        if item.meta['complete']:
+        if item.meta[COMPLETE]:
             error = 'Upload complete. Cannot delete fileupload garbage.'
         else:
             error = None


### PR DESCRIPTION
if you have a typo in them, it will trigger an exception and won't silently malfunction.

fixes #120.