### PR TITLE
upgrade xstatic package requirements, carefully, fixes #171

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'Pygments',
         'xstatic',
         'xstatic-bootbox',
-        'xstatic-bootstrap',
+        'xstatic-bootstrap<4.0.0.0',
         'xstatic-jquery',
         'xstatic-jquery-ui',
         'xstatic-jquery-file-upload',


### PR DESCRIPTION
i updated all the xstatic packages on pypi and now tried what upgrades can be done without causing obvious breakage.

most worked. \o/

but: upgrading bootstrap from 3.x to 4.x breaks the UI, so i restricted that to < 4.0.0.0.

it does a minor upgrade then, from 3.3.5(.1) to 3.3.7(.1).

on pypi, there is 4.1.3(.1) also.