### PR TITLE
add config for readthedocs, fixes #191

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+version: 2
+
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+  system_packages: false


### PR DESCRIPTION
python setup.py install does weird things, confusing misc.
xstatic-* packages. pip install . seems to work better.