### PR TITLE
Fixes REST api, and add some new functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     install_requires=[
         'Flask',
         'Pygments',
+        # 'python-magic',
         'xstatic',
         'xstatic-bootbox',
         'xstatic-bootstrap<4.0.0.0',

--- a/src/bepasty/apis/__init__.py
+++ b/src/bepasty/apis/__init__.py
@@ -1,7 +1,10 @@
 from flask import Blueprint
 
 from .lodgeit import LodgeitUpload
-from .rest import ItemDetailView, ItemDownloadView, ItemUploadView, InfoView
+from .rest import (
+    ItemDetailView, ItemDownloadView, ItemUploadView, InfoView,
+    ItemDeleteView, ItemLockView, ItemUnlockView
+)
 
 
 blueprint = Blueprint('bepasty_apis', __name__, url_prefix='/apis')
@@ -11,3 +14,6 @@ blueprint.add_url_rule('/rest', view_func=InfoView.as_view('api_info'))
 blueprint.add_url_rule('/rest/items', view_func=ItemUploadView.as_view('items'))
 blueprint.add_url_rule('/rest/items/<itemname:name>', view_func=ItemDetailView.as_view('items_detail'))
 blueprint.add_url_rule('/rest/items/<itemname:name>/download', view_func=ItemDownloadView.as_view('items_download'))
+blueprint.add_url_rule('/rest/items/<itemname:name>/delete', view_func=ItemDeleteView.as_view('items_delete'))
+blueprint.add_url_rule('/rest/items/<itemname:name>/lock', view_func=ItemLockView.as_view('items_lock'))
+blueprint.add_url_rule('/rest/items/<itemname:name>/unlock', view_func=ItemUnlockView.as_view('items_unlock'))

--- a/src/bepasty/apis/rest.py
+++ b/src/bepasty/apis/rest.py
@@ -15,7 +15,9 @@ from ..utils.name import ItemName
 from ..utils.permissions import CREATE, LIST, may
 from ..utils.upload import Upload, filter_internal, background_compute_hash
 from ..views.filelist import file_infos
+from ..views.delete import DeleteView
 from ..views.download import DownloadView
+from ..views.setkv import LockView, UnlockView
 
 
 # This wrapper to handle exception of REST api.
@@ -241,6 +243,42 @@ class ItemDownloadView(ItemDetailView):
     @rest_errorhandler
     def get(self, name):
         return super(ItemDetailView, self).get(name)
+
+
+class ItemDeleteView(DeleteView, RestBase):
+    def error(self, item, error):
+        raise Conflict(description=error)
+
+    def response(self, name):
+        return make_response()
+
+    @rest_errorhandler
+    def post(self, name):
+        return super(ItemDeleteView, self).post(name)
+
+
+class ItemLockView(LockView, RestBase):
+    def error(self, item, error):
+        raise Conflict(description=error)
+
+    def response(self, name):
+        return make_response()
+
+    @rest_errorhandler
+    def post(self, name):
+        return super(ItemLockView, self).post(name)
+
+
+class ItemUnlockView(UnlockView, RestBase):
+    def error(self, item, error):
+        raise Conflict(description=error)
+
+    def response(self, name):
+        return make_response()
+
+    @rest_errorhandler
+    def post(self, name):
+        return super(ItemUnlockView, self).post(name)
 
 
 class InfoView(RestBase):

--- a/src/bepasty/apis/rest.py
+++ b/src/bepasty/apis/rest.py
@@ -1,3 +1,4 @@
+import errno
 import base64
 import time
 from io import BytesIO
@@ -157,9 +158,17 @@ class ItemUploadView(RestBase):
             # Get file name from Transaction-ID and open from Storage
             trans_id_s = request.headers.get(TRANSACTION_ID)
             trans_id_b = trans_id_s if isinstance(trans_id_s, bytes_type) else trans_id_s.encode()
-            name_b = base64.b64decode(trans_id_b)
+            try:
+                name_b = base64_b64decode(trans_id_b)
+            except (base64.binascii.Error, TypeError):
+                raise BadRequest(description='{} is incorrect'.format(TRANSACTION_ID))
             name = name_b if isinstance(name_b, str) else name_b.decode()
-            item = current_app.storage.openwrite(name)
+            try:
+                item = current_app.storage.openwrite(name)
+            except (OSError, IOError) as e:
+                if e.errno == errno.ENOENT:
+                    raise BadRequest(description='{} is incorrect'.format(TRANSACTION_ID))
+                raise
             new_item = False
 
         response = None

--- a/src/bepasty/apis/rest.py
+++ b/src/bepasty/apis/rest.py
@@ -6,7 +6,7 @@ from io import BytesIO
 from flask import Response, make_response, url_for, jsonify, stream_with_context, request, current_app
 from flask.views import MethodView
 
-from ..constants import COMPLETE, FILENAME, SIZE, TYPE, TRANSACTION_ID
+from ..constants import COMPLETE, FILENAME, LOCKED, SIZE, TYPE, TRANSACTION_ID
 from ..utils._compat import bytes_type
 from ..utils.date_funcs import get_maxlife
 from ..utils.http import ContentRange, DownloadRange
@@ -163,7 +163,7 @@ class ItemDownloadView(MethodView):
                 return 'File not found', 404
             raise
 
-        if item.meta.get():
+        if item.meta.get(LOCKED):
             error = 'File Locked.'
         elif not item.meta.get(COMPLETE):
             error = 'Upload incomplete. Try again later.'

--- a/src/bepasty/apis/rest.py
+++ b/src/bepasty/apis/rest.py
@@ -13,7 +13,7 @@ from ..utils.date_funcs import get_maxlife
 from ..utils.http import ContentRange, DownloadRange
 from ..utils.name import ItemName
 from ..utils.permissions import CREATE, LIST, may
-from ..utils.upload import Upload, background_compute_hash
+from ..utils.upload import Upload, filter_internal, background_compute_hash
 from ..views.filelist import file_infos
 from ..views.download import DownloadView
 
@@ -199,7 +199,7 @@ class ItemUploadView(RestBase):
         for meta in file_infos():
             name = meta.pop(ID)
             ret[name] = {'uri': url_for('bepasty_apis.items_detail', name=name),
-                         'file-meta': meta}
+                         'file-meta': filter_internal(meta)}
         return jsonify(ret)
 
 
@@ -209,7 +209,7 @@ class ItemDetailView(DownloadView, RestBase):
 
     def response(self, item, name):
         return jsonify({'uri': url_for('bepasty_apis.items_detail', name=name),
-                        'file-meta': dict(item.meta)})
+                        'file-meta': filter_internal(dict(item.meta))})
 
     @rest_errorhandler
     def get(self, name):

--- a/src/bepasty/apis/rest.py
+++ b/src/bepasty/apis/rest.py
@@ -5,6 +5,7 @@ from io import BytesIO
 
 from flask import Response, make_response, url_for, jsonify, stream_with_context, request, current_app
 from flask.views import MethodView
+from werkzeug.exceptions import HTTPException, InternalServerError, MethodNotAllowed
 
 from ..constants import COMPLETE, FILENAME, LOCKED, SIZE, TYPE, TRANSACTION_ID
 from ..utils._compat import bytes_type
@@ -15,7 +16,44 @@ from ..utils.permissions import CREATE, LIST, READ, may
 from ..utils.upload import Upload, background_compute_hash
 
 
-class ItemUploadView(MethodView):
+# This wrapper to handle exception of REST api.
+# @blueprint.add_errorhandler decorator can do it though. We have
+# "/lodgeit/" in same blueprint, and didn't find the way to exclude
+# "/lodgeit/" from add_errorhandler to handle exception as web site,
+# not REST api.
+def rest_errorhandler(func):
+    def error_message(description, code):
+        # maybe better to return error as json?
+        return description, code
+
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except HTTPException as e:
+            return error_message(e.description, e.code)
+        except Exception:
+            if current_app.propagate_exceptions:
+                # if testing/debug mode, re-raise
+                raise
+            exc = InternalServerError()
+            return error_message(exc.description, exc.code)
+
+    return handler
+
+
+# Default handlers for REST api to handle error
+class RestBase(MethodView):
+    @rest_errorhandler
+    def get(self, *args, **kwargs):
+        raise MethodNotAllowed()
+
+    @rest_errorhandler
+    def post(self, *args, **kwargs):
+        raise MethodNotAllowed()
+
+
+class ItemUploadView(RestBase):
+    @rest_errorhandler
     def post(self):
         """
         Upload file via REST-API. Chunked Upload is supported.
@@ -117,6 +155,7 @@ class ItemUploadView(MethodView):
 
         return response
 
+    @rest_errorhandler
     def get(self):
         """
         Return the list of all files in bepasty, including metadata in the form:
@@ -139,7 +178,8 @@ class ItemUploadView(MethodView):
         return jsonify(ret)
 
 
-class ItemDetailView(MethodView):
+class ItemDetailView(RestBase):
+    @rest_errorhandler
     def get(self, name):
         if not may(READ):
             return 'Missing Permissions', 403
@@ -149,9 +189,10 @@ class ItemDetailView(MethodView):
                             'file-meta': dict(item.meta)})
 
 
-class ItemDownloadView(MethodView):
+class ItemDownloadView(RestBase):
     content_disposition = 'attachment'
 
+    @rest_errorhandler
     def get(self, name):
         if not may(READ):
             return 'Missing Permissions', 403
@@ -202,7 +243,8 @@ class ItemDownloadView(MethodView):
         return ret
 
 
-class InfoView(MethodView):
+class InfoView(RestBase):
+    @rest_errorhandler
     def get(self):
         return jsonify({'MAX_BODY_SIZE': current_app.config['MAX_BODY_SIZE'],
                         'MAX_ALLOWED_FILE_SIZE': current_app.config['MAX_ALLOWED_FILE_SIZE']})

--- a/src/bepasty/apis/rest.py
+++ b/src/bepasty/apis/rest.py
@@ -7,7 +7,7 @@ from flask.views import MethodView
 from werkzeug.exceptions import HTTPException, Conflict, InternalServerError, MethodNotAllowed
 
 from ..constants import FILENAME, ID, SIZE, TYPE, TRANSACTION_ID
-from ..utils._compat import bytes_type
+from ..utils._compat import bytes_type, base64_b64decode
 from ..utils.date_funcs import get_maxlife
 from ..utils.http import ContentRange, DownloadRange
 from ..utils.name import ItemName
@@ -54,6 +54,52 @@ class RestBase(MethodView):
 
 
 class ItemUploadView(RestBase):
+    def update_item(self, item, name):
+        # Check the actual size of the file on the server against limit
+        # Either 0 if new file or n bytes of already uploaded file
+        Upload.filter_size(item.data.size)
+
+        # Check Content-Range. Needs to be specified, even if only one chunk
+        if not request.headers.get("Content-Range"):
+            return 'Content-Range not specified', 400
+
+        # Get Content-Range and check if Range is consistent with server state
+        file_range = ContentRange.from_request()
+        if not item.data.size == file_range.begin:
+            return ('Content-Range inconsistent. Last byte on Server: %d' % item.data.size), 409
+
+        # Decode Base64 encoded request data
+        try:
+            raw_data = base64_b64decode(request.data)
+            file_data = BytesIO(raw_data)
+        except (base64.binascii.Error, TypeError):
+            return 'Data body could not decode', 400
+
+        # Write data chunk to item
+        Upload.data(item, file_data, len(raw_data), file_range.begin)
+
+        # Make a Response and create Transaction-ID from ItemName
+        response = make_response()
+        name_b = name if isinstance(name, bytes_type) else name.encode()
+        trans_id_b = base64.b64encode(name_b)
+        trans_id_s = trans_id_b if isinstance(trans_id_b, str) else trans_id_b.decode()
+        response.headers[TRANSACTION_ID] = trans_id_s
+
+        # Check if file is completely uploaded and set meta
+        if file_range.is_complete:
+            Upload.meta_complete(item, '')
+            item.meta[SIZE] = item.data.size
+            item.close()
+            background_compute_hash(current_app.storage, name)
+            # Set status 'successful' and return the new URL for the uploaded file
+            response.status = '201'
+            response.headers["Content-Location"] = url_for('bepasty_apis.items_detail', name=name)
+        else:
+            item.close()
+            response.status = '200'
+
+        return response
+
     @rest_errorhandler
     def post(self):
         """
@@ -106,6 +152,7 @@ class ItemUploadView(RestBase):
             Upload.meta_new(item, 0, file_name, file_type,
                             'application/octet-stream',
                             name, maxlife_stamp=maxlife_timestamp)
+            new_item = True
         else:
             # Get file name from Transaction-ID and open from Storage
             trans_id_s = request.headers.get(TRANSACTION_ID)
@@ -113,48 +160,16 @@ class ItemUploadView(RestBase):
             name_b = base64.b64decode(trans_id_b)
             name = name_b if isinstance(name_b, str) else name_b.decode()
             item = current_app.storage.openwrite(name)
+            new_item = False
 
-        # Check the actual size of the file on the server against limit
-        # Either 0 if new file or n bytes of already uploaded file
-        Upload.filter_size(item.data.size)
-
-        # Check Content-Range. Needs to be specified, even if only one chunk
-        if not request.headers.get("Content-Range"):
-            return 'Content-Range not specified', 400
-
-        # Get Content-Range and check if Range is consistent with server state
-        file_range = ContentRange.from_request()
-        if not item.data.size == file_range.begin:
-            return ('Content-Range inconsistent. Last byte on Server: %d' % item.data.size), 409
-
-        # Decode Base64 encoded request data
-        raw_data = base64.b64decode(request.data)
-        file_data = BytesIO(raw_data)
-
-        # Write data chunk to item
-        Upload.data(item, file_data, len(raw_data), file_range.begin)
-
-        # Make a Response and create Transaction-ID from ItemName
-        response = make_response()
-        name_b = name if isinstance(name, bytes_type) else name.encode()
-        trans_id_b = base64.b64encode(name_b)
-        trans_id_s = trans_id_b if isinstance(trans_id_b, str) else trans_id_b.decode()
-        response.headers[TRANSACTION_ID] = trans_id_s
-
-        # Check if file is completely uploaded and set meta
-        if file_range.is_complete:
-            Upload.meta_complete(item, '')
-            item.meta[SIZE] = item.data.size
-            item.close()
-            background_compute_hash(current_app.storage, name)
-            # Set status 'successful' and return the new URL for the uploaded file
-            response.status = '201'
-            response.headers["Content-Location"] = url_for('bepasty_apis.items_detail', name=name)
-        else:
-            item.close()
-            response.status = '200'
-
-        return response
+        res = None
+        try:
+            res = self.update_item(item, name)
+            return res
+        finally:
+            # If error response or exception on a new item path, remove item
+            if new_item and not isinstance(res, Response):
+                current_app.storage.remove(name)
 
     @rest_errorhandler
     def get(self):

--- a/src/bepasty/apis/rest.py
+++ b/src/bepasty/apis/rest.py
@@ -4,7 +4,7 @@ from io import BytesIO
 
 from flask import Response, make_response, url_for, jsonify, stream_with_context, request, current_app
 from flask.views import MethodView
-from werkzeug.exceptions import HTTPException, Conflict, InternalServerError, MethodNotAllowed
+from werkzeug.exceptions import HTTPException, BadRequest, Conflict, Forbidden, InternalServerError, MethodNotAllowed
 
 from ..constants import FILENAME, ID, SIZE, TYPE, TRANSACTION_ID
 from ..utils._compat import bytes_type, base64_b64decode
@@ -61,19 +61,19 @@ class ItemUploadView(RestBase):
 
         # Check Content-Range. Needs to be specified, even if only one chunk
         if not request.headers.get("Content-Range"):
-            return 'Content-Range not specified', 400
+            raise BadRequest(description='Content-Range not specified')
 
         # Get Content-Range and check if Range is consistent with server state
         file_range = ContentRange.from_request()
         if not item.data.size == file_range.begin:
-            return ('Content-Range inconsistent. Last byte on Server: %d' % item.data.size), 409
+            raise Conflict(description='Content-Range inconsistent. Last byte on Server: %d' % item.data.size)
 
         # Decode Base64 encoded request data
         try:
             raw_data = base64_b64decode(request.data)
             file_data = BytesIO(raw_data)
         except (base64.binascii.Error, TypeError):
-            return 'Data body could not decode', 400
+            raise BadRequest(description='Data body could not decode')
 
         # Write data chunk to item
         Upload.data(item, file_data, len(raw_data), file_range.begin)
@@ -129,7 +129,7 @@ class ItemUploadView(RestBase):
         The first check is the provided Content-Length. The second is the actual file size on the server.
         """
         if not may(CREATE):
-            return 'Missing Permissions', 403
+            raise Forbidden()
 
         # Collect all expected data from the Request
         file_type = request.headers.get("Content-Type")
@@ -162,13 +162,13 @@ class ItemUploadView(RestBase):
             item = current_app.storage.openwrite(name)
             new_item = False
 
-        res = None
+        response = None
         try:
-            res = self.update_item(item, name)
-            return res
+            response = self.update_item(item, name)
+            return response
         finally:
             # If error response or exception on a new item path, remove item
-            if new_item and not isinstance(res, Response):
+            if new_item and not isinstance(response, Response):
                 current_app.storage.remove(name)
 
     @rest_errorhandler
@@ -185,7 +185,7 @@ class ItemUploadView(RestBase):
             }
         """
         if not may(LIST):
-            return 'Missing Permissions', 403
+            raise Forbidden()
         ret = {}
         for meta in file_infos():
             name = meta.pop(ID)

--- a/src/bepasty/app.py
+++ b/src/bepasty/app.py
@@ -1,5 +1,6 @@
 import os
 import time
+import re
 
 from flask import (
     Flask,
@@ -32,14 +33,43 @@ class PrefixMiddleware(object):
         self.app = app
         self.prefix = prefix
 
-    def __call__(self, environ, start_response):
+    def __call__(self, environ, start_response, set_script_name=True):
         if environ['PATH_INFO'].startswith(self.prefix):
             environ['PATH_INFO'] = environ['PATH_INFO'][len(self.prefix):]
-            environ['SCRIPT_NAME'] = self.prefix
+            if set_script_name:
+                environ['SCRIPT_NAME'] = self.prefix
             return self.app(environ, start_response)
         else:
             start_response('404', [('Content-Type', 'text/plain')])
             return ['This URL does not belong to the bepasty app.'.encode()]
+
+
+class ReverseProxied(PrefixMiddleware):
+    def __init__(self, app, scheme, server, script_name='', prefix=None):
+        self.app = app
+        self.scheme = scheme
+        self.server = server
+        self.script_name = script_name or ''
+        self.prefix = prefix
+        if prefix is not None:
+            super(ReverseProxied, self).__init__(app, prefix=prefix)
+
+    def __call__(self, environ, start_response):
+        scheme = environ.get('HTTP_X_FORWARDED_PROTO') or self.scheme
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+        host = environ.get('HTTP_X_FORWARDED_HOST') or self.server
+        if host:
+            environ['HTTP_HOST'] = host
+        script_name = environ.get('HTTP_X_FORWARDED_PREFIX') or self.script_name
+        environ['SCRIPT_NAME'] = script_name
+
+        if self.prefix is not None:
+            return super(ReverseProxied, self).__call__(
+                environ, start_response, set_script_name=False
+            )
+        else:
+            return self.app(environ, start_response)
 
 
 def create_app():
@@ -49,8 +79,17 @@ def create_app():
     if os.environ.get('BEPASTY_CONFIG'):
         app.config.from_envvar('BEPASTY_CONFIG')
 
+    public_url = app.config.get('PUBLIC_URL')
     prefix = app.config.get('APP_BASE_PATH')
-    if prefix is not None:
+    if public_url is not None:
+        public_url.rstrip('/')
+        m = re.match('(https?)://([^/]+)(/.*)?', public_url)
+        if m:
+            app.wsgi_app = ReverseProxied(app.wsgi_app, scheme=m.group(1),
+                                          server=m.group(2),
+                                          script_name=m.group(3),
+                                          prefix=prefix)
+    elif prefix is not None:
         app.wsgi_app = PrefixMiddleware(app.wsgi_app, prefix=prefix)
 
     app.storage = create_storage(app)

--- a/src/bepasty/config.py
+++ b/src/bepasty/config.py
@@ -17,6 +17,12 @@ class Config(object):
     #: into SCRIPT_NAME (== APP_BASE_PATH) and the rest of PATH_INFO.
     APP_BASE_PATH = None  # '/bepasty'
 
+    #: Enable reverse proxy setup. This must set the public URL,
+    #: i.e. the URL as seen by user's browser.
+    #: Also it may use values set on proxy server,
+    #: X-Forwarded-Proto, X-Forwarded-Host, and X-Forwarded-Prefix.
+    PUBLIC_URL = None  # 'https://example.org:5000/bepasty'
+
     #: Whether files are automatically locked after upload.
     #:
     #: If you want to require admin approval and manual unlocking for each

--- a/src/bepasty/config.py
+++ b/src/bepasty/config.py
@@ -72,6 +72,10 @@ class Config(object):
         '': 1 * 1000 * 1000,
     }
 
+    #: Use python-magic module to guess mime type additionally, if
+    #: mime type is not determined from filename
+    USE_PYTHON_MAGIC = True
+
     #: Define storage backend, choose from:
     #:
     #: - 'filesystem'

--- a/src/bepasty/constants.py
+++ b/src/bepasty/constants.py
@@ -1,5 +1,6 @@
 FILENAME = 'filename'
 TYPE = 'type'
+TYPE_HINT = 'type-hint'
 LOCKED = 'locked'
 SIZE = 'size'
 COMPLETE = 'complete'
@@ -12,3 +13,6 @@ FOREVER = -1
 
 # headers
 TRANSACTION_ID = 'Transaction-ID'  # keep in sync with bepasty-cli
+
+# used internal only
+internal_meta = [TYPE_HINT]

--- a/src/bepasty/templates/_utils.html
+++ b/src/bepasty/templates/_utils.html
@@ -42,21 +42,15 @@
                 </td>
                 <td>
                     <div class="btn-group">
-                        <form action="{{ url_for('bepasty.display', name=file['id']) }}" method="get" class="btn-group">
-                            <button type="submit" class="btn btn-xs btn-info">
-                                display
-                            </button>
-                        </form>
-                        <form action="{{ url_for('bepasty.download', name=file['id']) }}" method="get" class="btn-group">
-                            <button type="submit" class="btn btn-xs btn-info">
-                                download
-                            </button>
-                        </form>
-                        <form action="{{ url_for('bepasty.inline', name=file['id']) }}" method="get" class="btn-group">
-                            <button type="submit" class="btn btn-xs btn-info">
-                                inline
-                            </button>
-                        </form>
+                        <a href="{{ url_for('bepasty.display', name=file['id']) }}" class="btn btn-xs btn-info">
+                            display
+                        </a>
+                        <a href="{{ url_for('bepasty.download', name=file['id']) }}" class="btn btn-xs btn-info">
+                            download
+                        </a>
+                        <a href="{{ url_for('bepasty.inline', name=file['id']) }}" class="btn btn-xs btn-info">
+                            inline
+                        </a>
                         {% if may(DELETE) %}
                             <form action="{{ url_for('bepasty.delete', name=file['id']) }}" method="post" class="btn-group">
                                 <button type="submit" class="btn btn-xs btn-danger">

--- a/src/bepasty/templates/display.html
+++ b/src/bepasty/templates/display.html
@@ -8,21 +8,15 @@
         </h1>
         <div class="btn-group">
             {% if not item.meta['locked'] or may(ADMIN) %}
-                <form id="qr-frm" action="{{ url_for('bepasty.qr', name=name) }}" method="get" class="btn-group">
-                    <button id="qr-btn" type="submit" class="btn btn-info">
-                        <span class="glyphicon glyphicon-qrcode"></span> QR
-                    </button>
-                </form>
-                <form id="download-frm" action="{{ url_for('bepasty.download', name=name) }}" method="get" class="btn-group">
-                    <button id="download-btn" type="submit" class="btn btn-info">
-                        <span class="glyphicon glyphicon-download-alt"></span> Download
-                    </button>
-                </form>
-                <form id="inline-frm" action="{{ url_for('bepasty.inline', name=name) }}" method="get" class="btn-group">
-                    <button id="inline-btn" type="submit" class="btn btn-info">
-                        <span class="glyphicon glyphicon-asterisk"></span> Inline
-                    </button>
-                </form>
+                <a id="qr-btn" href="{{ url_for('bepasty.qr', name=name) }}" class="btn btn-info">
+                    <span class="glyphicon glyphicon-qrcode"></span> QR
+                </a>
+                <a id="download-btn" href="{{ url_for('bepasty.download', name=name) }}" class="btn btn-info">
+                    <span class="glyphicon glyphicon-download-alt"></span> Download
+                </a>
+                <a id="inline-btn" href="{{ url_for('bepasty.inline', name=name) }}" class="btn btn-info">
+                    <span class="glyphicon glyphicon-asterisk"></span> Inline
+                </a>
             {% endif %}
             {% if may(DELETE) %}
                 <form id="del-frm" action="{{ url_for('bepasty.delete', name=name) }}" method="post" class="btn-group">

--- a/src/bepasty/tests/test_app.py
+++ b/src/bepasty/tests/test_app.py
@@ -1,0 +1,129 @@
+#
+# app tests
+#
+
+from flask import request, url_for
+from flask.views import MethodView
+
+import pytest
+
+from ..app import create_app
+from ..config import Config
+
+
+@pytest.fixture
+def app_fixture():
+    app_base_path = Config.APP_BASE_PATH
+    public_url = Config.PUBLIC_URL
+
+    yield
+
+    Config.APP_BASE_PATH = app_base_path
+    Config.PUBLIC_URL = public_url
+
+
+class TestView(MethodView):
+    callback = None
+
+    def get(self):
+        TestView.callback()
+        return 'done'
+
+
+def prepare(callback):
+    app = create_app()
+    app.add_url_rule('/test_call', view_func=TestView.as_view('test.test_call'))
+
+    TestView.callback = staticmethod(callback)
+    client = app.test_client()
+
+    assert app.config['APP_BASE_PATH'] == Config.APP_BASE_PATH
+    assert app.config['PUBLIC_URL'] == Config.PUBLIC_URL
+
+    return app, client
+
+
+def test_none(app_fixture):
+    Config.APP_BASE_PATH = None
+    Config.PUBLIC_URL = None
+
+    def none_callback():
+        url = url_for('test.test_call')
+        assert url == request.path
+        url = url_for('test.test_call', _external=True)
+        assert url == 'http://localhost' + request.path
+
+    app, client = prepare(none_callback)
+
+    response = client.get('/bepasty/test_call')
+    assert response.status_code == 404
+
+    response = client.get('/test_call')
+    assert response.status_code == 200
+    assert response.data == 'done'.encode()
+
+
+def test_prefix(app_fixture):
+    Config.APP_BASE_PATH = '/bepasty'
+    Config.PUBLIC_URL = None
+
+    def prefix_callback():
+        url = url_for('test.test_call')
+        assert url == Config.APP_BASE_PATH + request.path
+        url = url_for('test.test_call', _external=True)
+        assert url == 'http://localhost' + Config.APP_BASE_PATH + request.path
+
+    app, client = prepare(prefix_callback)
+
+    response = client.get('/test_call')
+    assert response.status_code == 404
+
+    response = client.get('/bepasty/test_call')
+    assert response.status_code == 200
+    assert response.data == 'done'.encode()
+
+
+def test_proxy(app_fixture):
+    Config.APP_BASE_PATH = None
+    public_base = '/bepasty1'
+    Config.PUBLIC_URL = 'https://example.org' + public_base
+
+    def proxy_callback():
+        url = url_for('test.test_call')
+        assert url == public_base + request.path
+        url = url_for('test.test_call', _external=True)
+        assert url == Config.PUBLIC_URL + request.path
+
+    app, client = prepare(proxy_callback)
+
+    response = client.get('/bepasty2/test_call')
+    assert response.status_code == 404
+    response = client.get('/bepasty1/test_call')
+    assert response.status_code == 404
+
+    response = client.get('/test_call')
+    assert response.status_code == 200
+    assert response.data == 'done'.encode()
+
+
+def test_proxy_prefix(app_fixture):
+    Config.APP_BASE_PATH = '/bepasty2'
+    public_base = '/bepasty1'
+    Config.PUBLIC_URL = 'https://example.org' + public_base
+
+    def proxy_prefix_callback():
+        url = url_for('test.test_call')
+        assert url == public_base + request.path
+        url = url_for('test.test_call', _external=True)
+        assert url == Config.PUBLIC_URL + request.path
+
+    app, client = prepare(proxy_prefix_callback)
+
+    response = client.get('/test_call')
+    assert response.status_code == 404
+    response = client.get('/bepasty1/test_call')
+    assert response.status_code == 404
+
+    response = client.get('/bepasty2/test_call')
+    assert response.status_code == 200
+    assert response.data == 'done'.encode()

--- a/src/bepasty/tests/test_date_funcs.py
+++ b/src/bepasty/tests/test_date_funcs.py
@@ -1,7 +1,12 @@
 import pytest
 
 from bepasty.constants import FOREVER
-from bepasty.utils.date_funcs import time_unit_to_sec
+from bepasty.utils.date_funcs import get_maxlife, time_unit_to_sec
+
+
+def test_get_maxlife():
+    assert get_maxlife({}, underscore=False) == 60 * 60 * 24 * 30
+    assert get_maxlife({}, underscore=True) == 60 * 60 * 24 * 30
 
 
 @pytest.mark.parametrize('unit,expectation', [

--- a/src/bepasty/tests/test_rest_server.py
+++ b/src/bepasty/tests/test_rest_server.py
@@ -120,6 +120,18 @@ class RestUrl:
     def download(self):
         return '/apis/rest/items/{}/download'.format(self.fid)
 
+    @property
+    def delete(self):
+        return '/apis/rest/items/{}/delete'.format(self.fid)
+
+    @property
+    def lock(self):
+        return '/apis/rest/items/{}/lock'.format(self.fid)
+
+    @property
+    def unlock(self):
+        return '/apis/rest/items/{}/unlock'.format(self.fid)
+
 
 def add_auth(user, password, headers=None):
     if headers is None:
@@ -793,6 +805,90 @@ def test_download_range(client_fixture):
                             total_size=len(data))
 
 
+def test_delete_basic(client_fixture):
+    app, client, faketime = client_fixture
+
+    faketime.set_time(100)
+
+    datas, metas = upload_files(client)
+
+    url = RestUrl('abcdefgh')
+
+    # delete ENOENT item
+    response = client.post(url.delete, headers=add_auth('user', 'admin'))
+    check_err_response(response, 404)
+
+    for fid in metas.keys():
+        url = RestUrl(fid)
+
+        # no permission
+        response = client.post(url.delete, headers=add_auth('user', 'invalid'))
+        check_err_response(response, 403)
+
+        # has permission
+        response = client.post(url.delete, headers=add_auth('user', 'full'))
+        check_err_response(response, 200)
+
+        # should already be deleted
+        response = client.post(url.delete, headers=add_auth('user', 'full'))
+        check_err_response(response, 404)
+
+
+def test_lock_basic(client_fixture):
+    app, client, faketime = client_fixture
+
+    faketime.set_time(100)
+
+    datas, metas = upload_files(client)
+
+    url = RestUrl('abcdefgh')
+
+    for u in (url.lock, url.unlock):
+        # lock/unlock ENOENT item
+        response = client.post(u, headers=add_auth('user', 'admin'))
+        check_err_response(response, 404)
+
+    for fid in metas.keys():
+        url = RestUrl(fid)
+
+        for u in (url.lock, url.unlock):
+            # lock/unlock, no permission (invalid user)
+            response = client.post(u, headers=add_auth('user', 'invalid'))
+            check_err_response(response, 403)
+
+            # lock/unlock, no permission (not admin)
+            response = client.post(u, headers=add_auth('user', 'full'))
+            check_err_response(response, 403)
+
+            # lock/unlock, has permission
+            response = client.post(u, headers=add_auth('user', 'admin'))
+            check_err_response(response, 200)
+
+        # lock item
+        response = client.post(url.lock, headers=add_auth('user', 'admin'))
+        check_err_response(response, 200)
+
+        # download locked item (should fail)
+        response = client.get(url.download, headers=add_auth('user', 'full'))
+        check_err_response(response, 403)
+
+        # download locked item with admin (should success)
+        response = client.get(url.download, headers=add_auth('user', 'admin'))
+        check_data_response(response, metas[fid], datas[fid])
+
+        # delete locked item (should fail)
+        response = client.post(url.delete, headers=add_auth('user', 'full'))
+        check_err_response(response, 403)
+
+        # delete locked item with admin (should success)
+        response = client.post(url.delete, headers=add_auth('user', 'admin'))
+        check_err_response(response, 200)
+
+        # deleted item
+        response = client.post(url.delete, headers=add_auth('user', 'admin'))
+        check_err_response(response, 404)
+
+
 def test_incomplete(client_fixture):
     _, client, _ = client_fixture
 
@@ -818,14 +914,31 @@ def test_incomplete(client_fixture):
     fid = list(response.json.keys())[0]
     # meta = list(response.json.values())[0]
 
-    # detail should error with incomplete
     url = RestUrl(fid)
+
+    # detail should error with incomplete
     response = client.get(url.detail, headers=add_auth('user', 'full'))
     check_err_response(response, 409)
 
     # download should error with incomplete
     response = client.get(url.download, headers=add_auth('user', 'full'))
     check_err_response(response, 409)
+
+    # lock should error with incomplete
+    response = client.post(url.lock, headers=add_auth('user', 'admin'))
+    check_err_response(response, 409)
+
+    # unlock should error with incomplete
+    response = client.post(url.unlock, headers=add_auth('user', 'admin'))
+    check_err_response(response, 409)
+
+    # delete should error with incomplete
+    response = client.post(url.delete, headers=add_auth('user', 'full'))
+    check_err_response(response, 409)
+
+    # delete by admin with incomplete should success
+    response = client.post(url.delete, headers=add_auth('user', 'admin'))
+    check_err_response(response, 200)
 
 
 def test_magic(client_fixture):

--- a/src/bepasty/tests/test_rest_server.py
+++ b/src/bepasty/tests/test_rest_server.py
@@ -554,6 +554,20 @@ def test_bad_data(client_fixture):
     assert len(os.listdir(app.config['STORAGE_FILESYSTEM_DIRECTORY'])) == 0
 
 
+def test_upload_maxlife(client_fixture):
+    """upload maxlife"""
+
+    _, client, _ = client_fixture
+
+    lifetime = ['foo', 'MINUTES']
+    response = _upload(client, UPLOAD_DATA, token='full', lifetime=lifetime)
+    assert response.status_code == 400
+
+    lifetime = ['1', 'foo']
+    response = _upload(client, UPLOAD_DATA, token='full', lifetime=lifetime)
+    assert response.status_code == 400
+
+
 def test_upload_too_big(client_fixture):
     app, client, _ = client_fixture
 

--- a/src/bepasty/tests/test_rest_server.py
+++ b/src/bepasty/tests/test_rest_server.py
@@ -1,0 +1,666 @@
+#
+# REST api tests
+#
+
+import os
+import base64
+import threading
+import time
+import hashlib
+from requests.auth import _basic_auth_str
+
+import pytest
+
+from ..app import create_app
+from ..config import Config
+from ..constants import FILENAME, TYPE, LOCKED, SIZE, COMPLETE, HASH, \
+    TIMESTAMP_DOWNLOAD, TIMESTAMP_UPLOAD, TIMESTAMP_MAX_LIFE, TRANSACTION_ID
+from ..utils.date_funcs import time_unit_to_sec
+
+UPLOAD_DATA = b"""\
+#!/usr/bin/python3
+
+print('hello, world')
+"""
+
+
+class FakeTime:
+    """Overwrite time.time to control the timestamp that is used in server"""
+
+    def __init__(self, now=None):
+        self.orig = time.time
+        self.now = now
+        self.set_time(self.now)
+
+    def set_time(self, now=None):
+        self.now = now
+        if now and time.time != self.get_time:
+            time.time = self.get_time
+        elif now is None and time.time == self.get_time:
+            time.time = self.orig
+
+    def get_time(self):
+        return self.now
+
+    def __enter__(self):
+        self.set_time(self.now)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.set_time(None)
+
+
+def wait_background():
+    """Wait background threads"""
+
+    main_thread = threading.current_thread()
+    for t in threading.enumerate():
+        if t is not main_thread:
+            t.join()
+
+
+@pytest.fixture
+def client_fixture(tmp_path):
+    with FakeTime() as faketime:
+        Config.PERMISSIONS = {
+            'admin': 'admin,list,create,read,delete',
+            'full': 'list,create,read,delete',
+            'none': '',
+        }
+        Config.STORAGE_FILESYSTEM_DIRECTORY = str(tmp_path)
+
+        app = create_app()
+        app.config['TESTING'] = True
+
+        with app.test_client() as client:
+            yield app, client, faketime
+
+        wait_background()
+
+
+class TmpConfig:
+    def __init__(self, app, tmp_config={}):
+        self.config = app.config
+        self.orig_config = {}
+        self.tmp_config = tmp_config
+        for k, v in tmp_config.items():
+            self.orig_config[k] = self.config[k]
+
+    def __enter__(self):
+        for k, v in self.tmp_config.items():
+            self.config[k] = v
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        for k, v in self.orig_config.items():
+            self.config[k] = self.orig_config[k]
+
+
+class RestUrl:
+    def __init__(self, fid=None):
+        self.fid = fid
+
+    @property
+    def config(self):
+        return '/apis/rest'
+
+    @property
+    def upload(self):
+        return '/apis/rest/items'
+
+    @property
+    def list(self):
+        return self.upload
+
+    @property
+    def detail(self):
+        return '/apis/rest/items/{}'.format(self.fid)
+
+    @property
+    def download(self):
+        return '/apis/rest/items/{}/download'.format(self.fid)
+
+
+def add_auth(user, password, headers=None):
+    if headers is None:
+        headers = dict()
+    headers.update({'Authorization': _basic_auth_str(user, password)})
+    return headers
+
+
+def test_invalid_url(client_fixture):
+    _, client, _ = client_fixture
+
+    # invalid url
+    response = client.get('/apis/rest/foo')
+    assert response.status_code == 404
+
+
+def check_response(response, code, ftype='application/json', check_data=True):
+    assert response.status_code == code
+    assert response.headers['Content-Type'] == ftype
+    if check_data:
+        assert int(response.headers['Content-Length']) == len(response.data)
+
+
+def check_err_response(response, code, check_data=True):
+    check_response(response, code, 'text/html; charset=utf-8', check_data)
+
+
+def check_data_response(response, meta, data, offset=None, total_size=None,
+                        check_data=True):
+    ftype = meta['file-meta'][TYPE]
+    filename = meta['file-meta'][FILENAME]
+    if offset is None:
+        offset = 0
+    if total_size is None:
+        total_size = len(data)
+
+    dispoition = 'attachment; filename="{}"'.format(filename)
+    range_str = 'bytes {}-{}/{}'.format(offset, offset + len(data) - 1,
+                                        total_size)
+
+    check_response(response, 200, ftype, check_data)
+    assert response.headers['Content-Disposition'] == dispoition
+    assert response.headers['Content-Range'] == range_str
+    if check_data:
+        assert data == response.data
+
+
+def check_json_response(response, metas, check_data=True):
+    check_response(response, 200, check_data=check_data)
+    if check_data:
+        assert metas == response.json
+
+
+def check_upload_response(response, code=201, check_data=True):
+    check_response(response, code, 'text/html; charset=utf-8', check_data)
+
+    if code == 200:
+        assert len(response.headers[TRANSACTION_ID]) > 0
+        return None
+
+    assert response.headers['Content-Location'].startswith('/apis/rest/items/')
+    return response.headers['Content-Location']
+
+
+def test_auth(client_fixture):
+    _, client, _ = client_fixture
+    url = RestUrl()
+
+    # basic auth (unknown user)
+    response = client.get(url.list, headers=add_auth('user', 'invalid'))
+    check_err_response(response, 403)
+    # basic auth (valid user)
+    response = client.get(url.list, headers=add_auth('user', 'full'))
+    check_response(response, 200)
+
+    # token auth (unknown user)
+    response = client.get(url.list + '?token=invalid')
+    check_err_response(response, 403)
+    # token auth (valid user)
+    response = client.get(url.list + '?token=full')
+    check_response(response, 200)
+
+
+def test_config(client_fixture):
+    app, client, _ = client_fixture
+
+    url = RestUrl()
+
+    # get server config (post should fail)
+    response = client.post(url.config)
+    check_err_response(response, 405)
+
+    # get server config
+    response = client.get(url.config)
+    check_response(response, 200)
+    assert len(response.json) == 2
+    assert response.json['MAX_ALLOWED_FILE_SIZE'] == app.config['MAX_ALLOWED_FILE_SIZE']
+    assert response.json['MAX_BODY_SIZE'] == app.config['MAX_BODY_SIZE']
+
+    # get server config (head)
+    response = client.head(url.config)
+    check_response(response, 200, check_data=False)
+
+
+def _upload(client, data, token=None, filename=None, ftype=None, lifetime=None,
+            range_str=None, trans_id=None, no_encode=False):
+    if data:
+        if no_encode:
+            payload = data
+        else:
+            payload = base64.b64encode(data)
+        payload_len = len(payload)
+    else:
+        payload = None
+        payload_len = 0
+
+    headers = {
+        'Content-Length': str(payload_len),
+    }
+    if range_str is None:
+        range_str = 'bytes 0-{}/{}'.format(payload_len - 1, payload_len)
+    headers['Content-Range'] = range_str
+    if filename is not None:
+        headers['Content-Filename'] = filename
+    if ftype is not None:
+        headers['Content-Type'] = ftype
+    if lifetime:
+        headers['Maxlife-Value'] = str(lifetime[0])
+        headers['Maxlife-Unit'] = lifetime[1]
+    if trans_id is not None:
+        headers[TRANSACTION_ID] = trans_id
+    if token is not None:
+        add_auth('user', token, headers)
+
+    response = client.post(RestUrl().upload, headers=headers, data=payload)
+    # FIXME: without waiting for background hash compute, following
+    # detail request may not have hash yet
+    wait_background()
+
+    return response
+
+
+def make_meta(data, filename=None, ftype=None, lifetime=None, uri=None):
+    h = hashlib.sha256()
+    h.update(data)
+
+    if lifetime is None:
+        # default maxlife is 1 MONTHS
+        lifetime = [1, 'MONTHS']
+    maxlife = int(time.time()) + time_unit_to_sec(lifetime[0], lifetime[1])
+
+    meta = {
+        'file-meta': {
+            COMPLETE: True,
+            FILENAME: filename,
+            HASH: h.hexdigest(),
+            LOCKED: False,
+            SIZE: len(data),
+            TIMESTAMP_DOWNLOAD: 0,
+            TIMESTAMP_MAX_LIFE: maxlife,
+            TIMESTAMP_UPLOAD: int(time.time()),
+            TYPE: ftype,
+        },
+        'uri': uri,
+    }
+    return meta
+
+
+def upload(client, data, token=None, filename=None, ftype=None, lifetime=None):
+    response = _upload(client, data, token, filename, ftype, lifetime)
+    uri = check_upload_response(response)
+
+    return make_meta(data, filename, ftype, lifetime, uri)
+
+
+def upload_files(client):
+    datas = {}
+    metas = {}
+
+    for i in (1, 2):
+
+        data = """\
+#!/usr/bin/python3
+
+print('hello,world {}')
+""".format(i).encode()
+
+        filename = '{}-test.py'.format(i)
+        lifetime = [1, 'YEARS']
+        ftype = 'text/x-python'
+
+        with FakeTime(int(time.time()) + i):
+            meta = upload(client, data, token='full', filename=filename,
+                          ftype=ftype, lifetime=lifetime)
+
+        fid = os.path.basename(meta['uri'])
+        datas[fid] = data
+        metas[fid] = meta
+
+    assert len(datas) == 2
+    assert len(metas) == 2
+
+    return datas, metas
+
+
+def check_detail_or_download(app, client, fid, meta, data, download=False):
+    url = RestUrl(fid=fid)
+
+    if download:
+        url = url.download
+    else:
+        url = url.detail
+
+    # post should fail
+    response = client.post(url)
+    check_err_response(response, 405)
+
+    # get with default (no permission)
+    response = client.get(url)
+    check_err_response(response, 403)
+    # head with default (no permission)
+    response = client.head(url)
+    check_err_response(response, 403, check_data=False)
+
+    with TmpConfig(app, {'DEFAULT_PERMISSIONS': 'read'}):
+        # head with default (has permission)
+        response = client.head(url)
+        if download:
+            check_data_response(response, meta, data, check_data=False)
+        else:
+            check_json_response(response, meta, check_data=False)
+
+        # get with default (has permission)
+        response = client.get(url)
+        if download:
+            check_data_response(response, meta, data)
+        else:
+            check_json_response(response, meta)
+
+    # get with no permission
+    response = client.get(url, headers=add_auth('user', 'none'))
+    check_err_response(response, 403)
+    # head with no permission
+    response = client.head(url, headers=add_auth('user', 'none'))
+    check_err_response(response, 403, check_data=False)
+
+    # head with permission
+    response = client.head(url, headers=add_auth('user', 'full'))
+    if download:
+        check_data_response(response, meta, data, check_data=False)
+    else:
+        check_json_response(response, meta, check_data=False)
+
+    # get with permission
+    response = client.get(url, headers=add_auth('user', 'full'))
+    if download:
+        check_data_response(response, meta, data)
+    else:
+        check_json_response(response, meta)
+
+
+def check_expired(client, fid, download=False):
+    url = RestUrl(fid=fid)
+    if download:
+        url = url.download
+    else:
+        url = url.detail
+
+    # expired items
+    response = client.get(url, headers=add_auth('user', 'full'))
+    check_err_response(response, 404)
+
+
+def test_upload_basic(client_fixture):
+    _, client, _ = client_fixture
+
+    # simple upload without permission
+    response = _upload(client, UPLOAD_DATA, token='none', filename='test.py',
+                       ftype='text/x-python', lifetime=[1, 'FOREVER'])
+    check_err_response(response, 403)
+
+    # simple upload with permission
+    upload(client, UPLOAD_DATA, token='full', filename='test.py',
+           ftype='text/x-python', lifetime=[1, 'FOREVER'])
+
+
+def test_upload_params(client_fixture):
+    app, client, faketime = client_fixture
+
+    faketime.set_time(100)
+
+    for filename, ftype in ((None, None), ('test.py', None), (None, 'text/plain')):
+        # upload without filename and/or ftype
+        meta = upload(client, UPLOAD_DATA, token='full',
+                      filename=filename, ftype=ftype)
+        fid = os.path.basename(meta['uri'])
+
+        url = RestUrl(fid)
+        # get meta for uploaded item
+        response = client.get(url.detail, headers=add_auth('user', 'full'))
+        check_json_response(response, None, check_data=False)
+        assert len(response.json) > 0
+        # copy generated meta
+        if filename:
+            assert response.json['file-meta'][FILENAME] == filename
+        else:
+            assert len(response.json['file-meta'][FILENAME]) > 0
+            meta['file-meta'][FILENAME] = response.json['file-meta'][FILENAME]
+        if ftype:
+            assert response.json['file-meta'][TYPE] == ftype
+        else:
+            assert len(response.json['file-meta'][TYPE]) > 0
+            meta['file-meta'][TYPE] = response.json['file-meta'][TYPE]
+
+        check_detail_or_download(app, client, fid, meta, UPLOAD_DATA)
+        check_detail_or_download(app, client, fid, meta, UPLOAD_DATA,
+                                 download=True)
+
+
+def test_upload_range(client_fixture):
+    app, client, faketime = client_fixture
+
+    faketime.set_time(100)
+
+    filename = 'test.py'
+    ftype = 'text/x-python'
+
+    # upload a first half of data
+    sep = 10
+    data = UPLOAD_DATA[:sep]
+    range_str = 'bytes {}-{}/{}'.format(0, sep - 1, sep + 1)
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_upload_response(response, 200)
+
+    # upload a rest of data
+    data = UPLOAD_DATA[sep:]
+    range_str = 'bytes {}-{}/{}'.format(sep, len(UPLOAD_DATA) - 1,
+                                        len(UPLOAD_DATA))
+    response = _upload(client, data, token='full', range_str=range_str,
+                       trans_id=response.headers[TRANSACTION_ID])
+    uri = check_upload_response(response)
+    fid = os.path.basename(uri)
+
+    # check a uploaded item
+    meta = make_meta(UPLOAD_DATA, filename=filename, ftype=ftype, uri=uri)
+    check_detail_or_download(app, client, fid, meta, UPLOAD_DATA)
+    check_detail_or_download(app, client, fid, meta, UPLOAD_DATA, download=True)
+
+    # upload again with not append position
+    data = UPLOAD_DATA[sep + 1:]
+    range_str = 'bytes {}-{}/{}'.format(sep + 1, len(UPLOAD_DATA) - 1,
+                                        len(UPLOAD_DATA))
+    response = _upload(client, data, token='full', range_str=range_str,
+                       trans_id=response.headers[TRANSACTION_ID])
+    check_err_response(response, 409)
+
+
+def test_upload_too_big(client_fixture):
+    app, client, _ = client_fixture
+
+    # upload too big size
+    size = 10000
+    with TmpConfig(app, {'MAX_ALLOWED_FILE_SIZE': size}):
+        ftype = 'text/x-bepasty-list'
+        data = bytes(b'a' * (size + 10))
+        response = _upload(client, data, token='full', ftype=ftype)
+        check_err_response(response, 413)
+
+
+def test_list_basic(client_fixture):
+    app, client, faketime = client_fixture
+
+    url = RestUrl()
+    faketime.set_time(100)
+
+    datas, metas = upload_files(client)
+
+    # list with default (no permission)
+    response = client.get(url.list)
+    check_err_response(response, 403)
+    response = client.head(url.list)
+    check_err_response(response, 403, check_data=False)
+
+    # list with default (has permission)
+    with TmpConfig(app, {'DEFAULT_PERMISSIONS': 'list'}):
+        response = client.get(url.list)
+        check_json_response(response, metas)
+        response = client.head(url.list)
+        check_json_response(response, metas, check_data=False)
+
+    # list with no permission
+    response = client.get(url.list, headers=add_auth('user', 'none'))
+    check_err_response(response, 403)
+    response = client.head(url.list, headers=add_auth('user', 'none'))
+    check_err_response(response, 403, check_data=False)
+
+    # list with permission
+    response = client.get(url.list, headers=add_auth('user', 'full'))
+    check_json_response(response, metas)
+    response = client.head(url.list, headers=add_auth('user', 'full'))
+    check_json_response(response, metas, check_data=False)
+
+    # adjust time to exceed lifetime
+    faketime.set_time(3600 * 24 * 365 * 2)
+    # list for expired items
+    response = client.get(url.list, headers=add_auth('user', 'full'))
+    check_json_response(response, {})
+
+
+def test_detail_basic(client_fixture):
+    app, client, faketime = client_fixture
+
+    faketime.set_time(100)
+
+    datas, metas = upload_files(client)
+
+    for fid in metas.keys():
+        data = datas[fid]
+        meta = metas[fid]
+
+        check_detail_or_download(app, client, fid, meta, data)
+
+        # detail of expired item
+        faketime.set_time(3600 * 24 * 365 * 2)
+        check_expired(client, fid)
+        # check again (should be deleted already)
+        faketime.set_time(100)
+        check_expired(client, fid)
+
+
+def test_download_basic(client_fixture):
+    app, client, faketime = client_fixture
+
+    faketime.set_time(100)
+
+    datas, metas = upload_files(client)
+
+    for fid in metas.keys():
+        data = datas[fid]
+        meta = metas[fid]
+
+        check_detail_or_download(app, client, fid, meta, data, download=True)
+
+        # download of expired item
+        faketime.set_time(3600 * 24 * 365 * 2)
+        check_expired(client, fid, download=True)
+        # check again (should be deleted already)
+        faketime.set_time(100)
+        check_expired(client, fid)
+
+
+def test_download_range(client_fixture):
+    _, client, faketime = client_fixture
+
+    faketime.set_time(100)
+
+    datas, metas = upload_files(client)
+
+    for fid in metas.keys():
+        data = datas[fid]
+        meta = metas[fid]
+
+        url = RestUrl(fid=fid)
+        headers = add_auth('user', 'full')
+
+        # Range: other=0-10 (invalid unit)
+        offset = 0
+        limit = 10
+        headers['Range'] = 'other={}-{}'.format(offset, limit - 1)
+        response = client.get(url.download, headers=headers)
+        check_err_response(response, 400)
+
+        # Range: bytes=10-0 (invalid range)
+        offset = 0
+        limit = 10
+        headers['Range'] = 'bytes={}-{}'.format(limit - 1, offset)
+        response = client.get(url.download, headers=headers)
+        check_err_response(response, 400)
+
+        # Range: bytes=0-10
+        offset = 0
+        limit = 10
+        headers['Range'] = 'bytes={}-{}'.format(offset, limit - 1)
+        response = client.get(url.download, headers=headers)
+        check_data_response(response, meta, data[offset:limit], offset=offset,
+                            total_size=len(data))
+
+        # Range: bytes=-9
+        # FIXME: suffix-byte-range-spec is not supported for now
+        offset = 0
+        limit = 10
+        headers['Range'] = 'bytes=-{}'.format(limit - 1)
+        response = client.get(url.download, headers=headers)
+        check_err_response(response, 400)
+
+        # Range: bytes=10-<limit - 1>
+        offset = 10
+        limit = len(data)
+        headers['Range'] = 'bytes={}-{}'.format(offset, limit - 1)
+        response = client.get(url.download, headers=headers)
+        check_data_response(response, meta, data[offset:limit], offset=offset,
+                            total_size=len(data))
+
+        # Range: bytes=10-
+        offset = 10
+        limit = len(data)
+        headers['Range'] = 'bytes={}-'.format(offset)
+        response = client.get(url.download, headers=headers)
+        check_data_response(response, meta, data[offset:limit], offset=offset,
+                            total_size=len(data))
+
+
+def test_incomplete(client_fixture):
+    _, client, _ = client_fixture
+
+    filename = 'test.py'
+    ftype = 'text/x-python'
+
+    # upload a half of data to make incomplete
+    sep = 10
+    data = UPLOAD_DATA[:sep]
+    range_str = 'bytes {}-{}/{}'.format(0, sep - 1, len(UPLOAD_DATA))
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_upload_response(response, 200)
+
+    # get incomplete item from list
+    url = RestUrl()
+    headers = add_auth('user', 'full')
+    response = client.get(url.list, headers=headers)
+    check_response(response, 200)
+    assert len(response.json) == 1
+
+    fid = list(response.json.keys())[0]
+    # meta = list(response.json.values())[0]
+
+    # detail should error with incomplete
+    url = RestUrl(fid)
+    response = client.get(url.detail, headers=add_auth('user', 'full'))
+    check_err_response(response, 403)
+
+    # download should error with incomplete
+    response = client.get(url.download, headers=add_auth('user', 'full'))
+    check_err_response(response, 403)

--- a/src/bepasty/tests/test_rest_server.py
+++ b/src/bepasty/tests/test_rest_server.py
@@ -659,8 +659,8 @@ def test_incomplete(client_fixture):
     # detail should error with incomplete
     url = RestUrl(fid)
     response = client.get(url.detail, headers=add_auth('user', 'full'))
-    check_err_response(response, 403)
+    check_err_response(response, 409)
 
     # download should error with incomplete
     response = client.get(url.download, headers=add_auth('user', 'full'))
-    check_err_response(response, 403)
+    check_err_response(response, 409)

--- a/src/bepasty/tests/test_rest_server.py
+++ b/src/bepasty/tests/test_rest_server.py
@@ -224,7 +224,7 @@ def test_config(client_fixture):
 
 
 def _upload(client, data, token=None, filename=None, ftype=None, lifetime=None,
-            range_str=None, trans_id=None, no_encode=False):
+            range_str=None, trans_id=None, no_encode=False, no_range=False):
     if data:
         if no_encode:
             payload = data
@@ -240,7 +240,8 @@ def _upload(client, data, token=None, filename=None, ftype=None, lifetime=None,
     }
     if range_str is None:
         range_str = 'bytes 0-{}/{}'.format(payload_len - 1, payload_len)
-    headers['Content-Range'] = range_str
+    if not no_range:
+        headers['Content-Range'] = range_str
     if filename is not None:
         headers['Content-Filename'] = filename
     if ftype is not None:
@@ -446,10 +447,70 @@ def test_upload_range(client_fixture):
     filename = 'test.py'
     ftype = 'text/x-python'
 
-    # upload a first half of data
     sep = 10
     data = UPLOAD_DATA[:sep]
-    range_str = 'bytes {}-{}/{}'.format(0, sep - 1, sep + 1)
+
+    # (invalid no Content-Range:)
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, no_range=True)
+    check_err_response(response, 400)
+
+    # Content-Range: invalid (invalid format)
+    range_str = 'invalid'
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_err_response(response, 400)
+
+    # Content-Range: bytes invalid (invalid format)
+    range_str = 'bytes invalid'
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_err_response(response, 400)
+
+    # Content-Range: other 0-<sep - 1>/<len(data)> (invalid unit)
+    range_str = 'other {}-{}/{}'.format(0, sep - 1, len(UPLOAD_DATA))
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_err_response(response, 400)
+
+    # Content-Range: bytes invalid-<sep - 1>/<len(data)> (invalid first)
+    range_str = 'bytes invalid-{}/{}'.format(sep - 1, len(UPLOAD_DATA))
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_err_response(response, 400)
+
+    # Content-Range: bytes 0-invalid/<len(data)> (invalid last)
+    range_str = 'bytes {}-invalid/{}'.format(0, len(UPLOAD_DATA))
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_err_response(response, 400)
+
+    # Content-Range: bytes <sep - 1>-0/<len(data)> (invalid first > last)
+    range_str = 'bytes {}-{}/{}'.format(sep - 1, 0, len(UPLOAD_DATA))
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_err_response(response, 400)
+
+    # Content-Range: bytes 0-<sep - 1>/* (not supported)
+    range_str = 'bytes {}-{}/*'.format(0, sep - 1)
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_err_response(response, 400)
+
+    # Content-Range: bytes */<len(data)> (not supported)
+    range_str = 'bytes */{}'.format(len(UPLOAD_DATA))
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_err_response(response, 400)
+
+    # Content-Range: bytes */* (not supported)
+    range_str = 'bytes */*'
+    response = _upload(client, data, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str)
+    check_err_response(response, 400)
+
+    # upload a first half of data
+    range_str = 'bytes {}-{}/{}'.format(0, sep - 1, len(UPLOAD_DATA))
     response = _upload(client, data, token='full', filename=filename,
                        ftype=ftype, range_str=range_str)
     check_upload_response(response, 200)
@@ -601,6 +662,20 @@ def test_download_range(client_fixture):
         url = RestUrl(fid=fid)
         headers = add_auth('user', 'full')
 
+        # Range: other (invalid format)
+        offset = 0
+        limit = 10
+        headers['Range'] = 'other'
+        response = client.get(url.download, headers=headers)
+        check_err_response(response, 400)
+
+        # Range: bytes=invalid (invalid format)
+        offset = 0
+        limit = 10
+        headers['Range'] = 'bytes=invalid'
+        response = client.get(url.download, headers=headers)
+        check_err_response(response, 400)
+
         # Range: other=0-10 (invalid unit)
         offset = 0
         limit = 10
@@ -608,10 +683,31 @@ def test_download_range(client_fixture):
         response = client.get(url.download, headers=headers)
         check_err_response(response, 400)
 
-        # Range: bytes=10-0 (invalid range)
+        # Range: bytes=invalid-10 (invalid first)
+        offset = 0
+        limit = 10
+        headers['Range'] = 'bytes=invalid-{}'.format(limit - 1)
+        response = client.get(url.download, headers=headers)
+        check_err_response(response, 400)
+
+        # Range: bytes=0-invalid (invalid last)
+        offset = 0
+        limit = 10
+        headers['Range'] = 'other={}-invalid'.format(offset)
+        response = client.get(url.download, headers=headers)
+        check_err_response(response, 400)
+
+        # Range: bytes=10-0 (invalid first > last)
         offset = 0
         limit = 10
         headers['Range'] = 'bytes={}-{}'.format(limit - 1, offset)
+        response = client.get(url.download, headers=headers)
+        check_err_response(response, 400)
+
+        # Range: bytes=0-9,10-<limit - 1> (not supported for now)
+        offset = 0
+        limit = len(data)
+        headers['Range'] = 'bytes={}-9,10-{}'.format(offset, limit - 1)
         response = client.get(url.download, headers=headers)
         check_err_response(response, 400)
 

--- a/src/bepasty/tests/test_rest_server.py
+++ b/src/bepasty/tests/test_rest_server.py
@@ -580,6 +580,29 @@ def test_upload_maxlife(client_fixture):
     assert response.status_code == 400
 
 
+def test_upload_transaction_id(client_fixture):
+    app, client, faketime = client_fixture
+
+    faketime.set_time(100)
+
+    sep = 10
+    data = UPLOAD_DATA[sep:]
+    range_str = 'bytes {}-{}/{}'.format(sep, len(UPLOAD_DATA) - 1,
+                                        len(UPLOAD_DATA))
+
+    # upload with invalid Transaction-ID
+    trans_id = 'invalid'
+    response = _upload(client, data, token='full', range_str=range_str,
+                       trans_id=trans_id)
+    check_err_response(response, 400)
+
+    # upload with Transaction-ID for invalid filename
+    trans_id = base64.b64encode(b'invalid')
+    response = _upload(client, data, token='full', range_str=range_str,
+                       trans_id=trans_id)
+    check_err_response(response, 400)
+
+
 def test_upload_too_big(client_fixture):
     app, client, _ = client_fixture
 

--- a/src/bepasty/tests/test_rest_server.py
+++ b/src/bepasty/tests/test_rest_server.py
@@ -550,6 +550,12 @@ def test_bad_data(client_fixture):
     filename = 'test.py'
     ftype = 'text/x-python'
 
+    # upload without Content-Length
+    range_str = 'bytes 0-{}/{}'.format(len(UPLOAD_DATA) - 1, len(UPLOAD_DATA))
+    response = _upload(client, None, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str, no_encode=True)
+    check_err_response(response, 400)
+
     # upload invalid base64 encode
     range_str = 'bytes 0-{}/{}'.format(len(UPLOAD_DATA) - 1, len(UPLOAD_DATA))
     response = _upload(client, UPLOAD_DATA, token='full', filename=filename,

--- a/src/bepasty/tests/test_rest_server.py
+++ b/src/bepasty/tests/test_rest_server.py
@@ -7,6 +7,7 @@ import base64
 import threading
 import time
 import hashlib
+import re
 from requests.auth import _basic_auth_str
 
 import pytest
@@ -142,8 +143,13 @@ def check_response(response, code, ftype='application/json', check_data=True):
         assert int(response.headers['Content-Length']) == len(response.data)
 
 
+re_html_tag = re.compile(r'<.+>')
+
+
 def check_err_response(response, code, check_data=True):
     check_response(response, code, 'text/html; charset=utf-8', check_data)
+    # check if doesn't have html tag
+    assert not re_html_tag.match(response.data.decode())
 
 
 def check_data_response(response, meta, data, offset=None, total_size=None,

--- a/src/bepasty/tests/test_rest_server.py
+++ b/src/bepasty/tests/test_rest_server.py
@@ -477,6 +477,22 @@ def test_upload_range(client_fixture):
     check_err_response(response, 409)
 
 
+def test_bad_data(client_fixture):
+    app, client, _ = client_fixture
+
+    filename = 'test.py'
+    ftype = 'text/x-python'
+
+    # upload invalid base64 encode
+    range_str = 'bytes 0-{}/{}'.format(len(UPLOAD_DATA) - 1, len(UPLOAD_DATA))
+    response = _upload(client, UPLOAD_DATA, token='full', filename=filename,
+                       ftype=ftype, range_str=range_str, no_encode=True)
+    check_err_response(response, 400)
+
+    # server should not left garbage files
+    assert len(os.listdir(app.config['STORAGE_FILESYSTEM_DIRECTORY'])) == 0
+
+
 def test_upload_too_big(client_fixture):
     app, client, _ = client_fixture
 

--- a/src/bepasty/utils/_compat.py
+++ b/src/bepasty/utils/_compat.py
@@ -3,6 +3,7 @@
 # License: BSD 2-clause, see LICENSE for details.
 
 import sys
+import base64
 
 __all__ = ['urljoin', 'urlparse']
 
@@ -14,9 +15,15 @@ if PY2:
     range_type = xrange  # noqa: F821
     bytes_type = str
     iteritems = lambda d: d.iteritems()  # noqa: E731
+
+    def base64_b64decode(data):
+        return base64.b64decode(data)
 else:
     from urllib.parse import urlparse, urljoin
 
     range_type = range
     bytes_type = bytes
     iteritems = lambda d: iter(d.items())  # noqa: E731
+
+    def base64_b64decode(data):
+        return base64.b64decode(data, validate=True)

--- a/src/bepasty/utils/date_funcs.py
+++ b/src/bepasty/utils/date_funcs.py
@@ -1,5 +1,6 @@
 import time
 from flask import current_app
+from werkzeug.exceptions import BadRequest
 
 from ..constants import FOREVER, TIMESTAMP_MAX_LIFE
 
@@ -10,7 +11,10 @@ def get_maxlife(data, underscore):
     unit = data.get(unit_key, unit_default).upper()
     value_key = 'maxlife_value' if underscore else 'maxlife-value'
     value_default = '1'
-    value = int(data.get(value_key, value_default))
+    try:
+        value = int(data.get(value_key, value_default))
+    except (ValueError, TypeError):
+        raise BadRequest(description='Maxlife-Value header is incorrect')
     return time_unit_to_sec(value, unit)
 
 
@@ -31,6 +35,8 @@ def time_unit_to_sec(value, unit):
         'YEARS': 60 * 60 * 24 * 365,
         'FOREVER': FOREVER,
     }
+    if units.get(unit) is None:
+        raise BadRequest(description='Maxlife-Unit header is incorrect')
     secs = units[unit] * value if units[unit] > 0 else units[unit]
     return secs
 

--- a/src/bepasty/utils/date_funcs.py
+++ b/src/bepasty/utils/date_funcs.py
@@ -6,7 +6,7 @@ from ..constants import FOREVER, TIMESTAMP_MAX_LIFE
 
 def get_maxlife(data, underscore):
     unit_key = 'maxlife_unit' if underscore else 'maxlife-unit'
-    unit_default = 'MONTH'
+    unit_default = 'MONTHS'
     unit = data.get(unit_key, unit_default).upper()
     value_key = 'maxlife_value' if underscore else 'maxlife-value'
     value_default = '1'

--- a/src/bepasty/utils/upload.py
+++ b/src/bepasty/utils/upload.py
@@ -1,8 +1,9 @@
 import re
 import time
 import mimetypes
+from werkzeug.exceptions import BadRequest, RequestEntityTooLarge
 
-from flask import abort, current_app
+from flask import current_app
 
 from ..constants import (
     COMPLETE,
@@ -36,9 +37,12 @@ class Upload(object):
         Filter size.
         Check for advertised size.
         """
-        i = int(i)
+        try:
+            i = int(i)
+        except (ValueError, TypeError):
+            raise BadRequest(description='Size is incorrect')
         if i > current_app.config['MAX_ALLOWED_FILE_SIZE']:
-            abort(413)
+            raise RequestEntityTooLarge()
         return i
 
     @classmethod

--- a/src/bepasty/views/delete.py
+++ b/src/bepasty/views/delete.py
@@ -10,6 +10,12 @@ from ..utils.permissions import ADMIN, DELETE, may
 
 
 class DeleteView(MethodView):
+    def error(self, item, error):
+        return render_template('error.html', heading=item.meta[FILENAME], body=error), 409
+
+    def response(self, name):
+        return redirect_next_referrer('bepasty.index')
+
     def post(self, name):
         if not may(DELETE):
             raise Forbidden()
@@ -17,7 +23,7 @@ class DeleteView(MethodView):
             with current_app.storage.open(name) as item:
                 if not item.meta[COMPLETE] and not may(ADMIN):
                     error = 'Upload incomplete. Try again later.'
-                    return render_template('error.html', heading=item.meta[FILENAME], body=error), 409
+                    self.error(item, error)
 
                 if item.meta[LOCKED] and not may(ADMIN):
                     raise Forbidden()
@@ -29,4 +35,4 @@ class DeleteView(MethodView):
                 raise NotFound()
             raise
 
-        return redirect_next_referrer('bepasty.index')
+        return self.response(name)

--- a/src/bepasty/views/setkv.py
+++ b/src/bepasty/views/setkv.py
@@ -19,6 +19,12 @@ class SetKeyValueView(MethodView):
     KEY = None
     NEXT_VALUE = None
 
+    def error(self, item, error):
+        return render_template('error.html', heading=item.meta[FILENAME], body=error), 409
+
+    def response(self, name):
+        return redirect_next_referrer('bepasty.display', name=name)
+
     def post(self, name):
         if self.REQUIRED_PERMISSION is not None and not may(self.REQUIRED_PERMISSION):
             raise Forbidden()
@@ -31,9 +37,9 @@ class SetKeyValueView(MethodView):
                 else:
                     error = None
                 if error:
-                    return render_template('error.html', heading=item.meta[FILENAME], body=error), 409
+                    return self.error(item, error)
                 item.meta[self.KEY] = self.NEXT_VALUE
-            return redirect_next_referrer('bepasty.display', name=name)
+            return self.response(name)
 
         except (OSError, IOError) as e:
             if e.errno == errno.ENOENT:


### PR DESCRIPTION
This PR does,

- fixes several bugs, adds tests, generalize error response for REST api
- 78dbb01: adds new REST api for delete/lock/unlock (for example, my own client uses those)
- 05976a4: allow to copy link for display etc. buttons in web site
- 3627356: optionally support python-magic to detect file type (this adds TYPE_HINT metadata, so can be arguable)

(edited: latest one fixed flake8 warning)

Thanks.