### PR TITLE
Support reverse proxy setup

### DIFF
--- a/src/bepasty/config.py
+++ b/src/bepasty/config.py
@@ -20,7 +20,8 @@ class Config(object):
     #: Enable reverse proxy setup. This must set the public URL,
     #: i.e. the URL as seen by user's browser.
     #: Also it may use values set on proxy server,
-    #: X-Forwarded-Proto, X-Forwarded-Host, and X-Forwarded-Prefix.
+    #: X-Forwarded-For, X-Forwarded-Proto, X-Forwarded-Host, X-Forwarded-Port,
+    #: and X-Forwarded-Prefix.
     PUBLIC_URL = None  # 'https://example.org:5000/bepasty'
 
     #: Whether files are automatically locked after upload.

--- a/src/bepasty/config.py
+++ b/src/bepasty/config.py
@@ -17,6 +17,12 @@ class Config(object):
     #: into SCRIPT_NAME (== APP_BASE_PATH) and the rest of PATH_INFO.
     APP_BASE_PATH = None  # '/bepasty'
 
+    #: Enable reverse proxy setup. This must set the public URL,
+    #: i.e. the URL as seen by user's browser.
+    #: Also it may use values set on proxy server,
+    #: X-Forwarded-Proto, X-Forwarded-Host, and X-Forwarded-Prefix.
+    PUBLIC_URL = None  # 'https://example.org:5000/bepasty'
+
     #: Whether files are automatically locked after upload.
     #:
     #: If you want to require admin approval and manual unlocking for each

--- a/src/bepasty/tests/test_app.py
+++ b/src/bepasty/tests/test_app.py
@@ -1,0 +1,153 @@
+#
+# app tests
+#
+
+from flask import request, url_for
+from flask.views import MethodView
+
+import pytest
+
+from ..app import create_app
+from ..config import Config
+
+
+@pytest.fixture
+def app_fixture():
+    app_base_path = Config.APP_BASE_PATH
+    public_url = Config.PUBLIC_URL
+
+    yield
+
+    Config.APP_BASE_PATH = app_base_path
+    Config.PUBLIC_URL = public_url
+
+
+class TestView(MethodView):
+    callback = None
+
+    def get(self):
+        TestView.callback()
+        return 'done'
+
+
+def prepare(callback):
+    app = create_app()
+    app.add_url_rule('/test_call', view_func=TestView.as_view('test.test_call'))
+
+    TestView.callback = staticmethod(callback)
+    client = app.test_client()
+
+    assert app.config['APP_BASE_PATH'] == Config.APP_BASE_PATH
+    assert app.config['PUBLIC_URL'] == Config.PUBLIC_URL
+
+    return app, client
+
+
+def test_none(app_fixture):
+    Config.APP_BASE_PATH = None
+    Config.PUBLIC_URL = None
+
+    def none_callback():
+        url = url_for('test.test_call')
+        assert url == request.path
+        url = url_for('test.test_call', _external=True)
+        assert url == 'http://localhost' + request.path
+
+    app, client = prepare(none_callback)
+
+    response = client.get('/bepasty/test_call')
+    assert response.status_code == 404
+
+    response = client.get('/test_call')
+    assert response.status_code == 200
+    assert response.data == 'done'.encode()
+
+
+def test_prefix(app_fixture):
+    Config.APP_BASE_PATH = '/bepasty'
+    Config.PUBLIC_URL = None
+
+    def prefix_callback():
+        url = url_for('test.test_call')
+        assert url == Config.APP_BASE_PATH + request.path
+        url = url_for('test.test_call', _external=True)
+        assert url == 'http://localhost' + Config.APP_BASE_PATH + request.path
+
+    app, client = prepare(prefix_callback)
+
+    response = client.get('/test_call')
+    assert response.status_code == 404
+
+    response = client.get('/bepasty/test_call')
+    assert response.status_code == 200
+    assert response.data == 'done'.encode()
+
+
+def test_proxy(app_fixture):
+    Config.APP_BASE_PATH = None
+    public_base = '/bepasty1'
+    Config.PUBLIC_URL = 'https://example.org' + public_base
+
+    def proxy_callback():
+        url = url_for('test.test_call')
+        assert url == public_base + request.path
+        url = url_for('test.test_call', _external=True)
+        assert url == Config.PUBLIC_URL + request.path
+
+    app, client = prepare(proxy_callback)
+
+    response = client.get('/bepasty2/test_call')
+    assert response.status_code == 404
+    response = client.get('/bepasty1/test_call')
+    assert response.status_code == 404
+
+    response = client.get('/test_call')
+    assert response.status_code == 200
+    assert response.data == 'done'.encode()
+
+
+def test_proxy_prefix(app_fixture):
+    Config.APP_BASE_PATH = '/bepasty2'
+    public_base = '/bepasty1'
+    Config.PUBLIC_URL = 'https://example.org' + public_base
+
+    def proxy_prefix_callback():
+        url = url_for('test.test_call')
+        assert url == public_base + request.path
+        url = url_for('test.test_call', _external=True)
+        assert url == Config.PUBLIC_URL + request.path
+
+    app, client = prepare(proxy_prefix_callback)
+
+    response = client.get('/test_call')
+    assert response.status_code == 404
+    response = client.get('/bepasty1/test_call')
+    assert response.status_code == 404
+
+    response = client.get('/bepasty2/test_call')
+    assert response.status_code == 200
+    assert response.data == 'done'.encode()
+
+
+def test_proxy_prefix_slash(app_fixture):
+    Config.APP_BASE_PATH = '/bepasty2'
+    public_base = '/bepasty1'
+    public_url = 'https://example.org' + public_base
+    Config.PUBLIC_URL = public_url + '/'
+
+    def proxy_prefix_callback():
+        url = url_for('test.test_call')
+        assert url == public_base + request.path
+        url = url_for('test.test_call', _external=True)
+        assert url == public_url + request.path
+
+    app, client = prepare(proxy_prefix_callback)
+
+    response = client.get('/test_call')
+    assert response.status_code == 404
+    response = client.get('/bepasty1/test_call')
+    assert response.status_code == 404
+
+    response = client.get('/bepasty2/test_call')
+    assert response.status_code == 200
+    assert response.data == 'done'.encode()


### PR DESCRIPTION
On reverse proxy setup, some uses wrong URL, for example, QR uses
internal hostname.

To fixes, this adds new "PUBLIC_URL" in config to tell URL for
frontend side, then uses it to setup flask environ to use proper URL.