### PR TITLE
Use simple link in list/display view instead of <form>

### DIFF
--- a/src/bepasty/templates/_utils.html
+++ b/src/bepasty/templates/_utils.html
@@ -42,21 +42,15 @@
                 </td>
                 <td>
                     <div class="btn-group">
-                        <form action="{{ url_for('bepasty.display', name=file['id']) }}" method="get" class="btn-group">
-                            <button type="submit" class="btn btn-xs btn-info">
-                                display
-                            </button>
-                        </form>
-                        <form action="{{ url_for('bepasty.download', name=file['id']) }}" method="get" class="btn-group">
-                            <button type="submit" class="btn btn-xs btn-info">
-                                download
-                            </button>
-                        </form>
-                        <form action="{{ url_for('bepasty.inline', name=file['id']) }}" method="get" class="btn-group">
-                            <button type="submit" class="btn btn-xs btn-info">
-                                inline
-                            </button>
-                        </form>
+                        <a href="{{ url_for('bepasty.display', name=file['id']) }}" class="btn btn-xs btn-info">
+                            display
+                        </a>
+                        <a href="{{ url_for('bepasty.download', name=file['id']) }}" class="btn btn-xs btn-info">
+                            download
+                        </a>
+                        <a href="{{ url_for('bepasty.inline', name=file['id']) }}" class="btn btn-xs btn-info">
+                            inline
+                        </a>
                         {% if may(DELETE) %}
                             <form action="{{ url_for('bepasty.delete', name=file['id']) }}" method="post" class="btn-group">
                                 <button type="submit" class="btn btn-xs btn-danger">

--- a/src/bepasty/templates/display.html
+++ b/src/bepasty/templates/display.html
@@ -8,21 +8,15 @@
         </h1>
         <div class="btn-group">
             {% if not item.meta['locked'] or may(ADMIN) %}
-                <form id="qr-frm" action="{{ url_for('bepasty.qr', name=name) }}" method="get" class="btn-group">
-                    <button id="qr-btn" type="submit" class="btn btn-info">
-                        <span class="glyphicon glyphicon-qrcode"></span> QR
-                    </button>
-                </form>
-                <form id="download-frm" action="{{ url_for('bepasty.download', name=name) }}" method="get" class="btn-group">
-                    <button id="download-btn" type="submit" class="btn btn-info">
-                        <span class="glyphicon glyphicon-download-alt"></span> Download
-                    </button>
-                </form>
-                <form id="inline-frm" action="{{ url_for('bepasty.inline', name=name) }}" method="get" class="btn-group">
-                    <button id="inline-btn" type="submit" class="btn btn-info">
-                        <span class="glyphicon glyphicon-asterisk"></span> Inline
-                    </button>
-                </form>
+                <a id="qr-btn" href="{{ url_for('bepasty.qr', name=name) }}" class="btn btn-info">
+                    <span class="glyphicon glyphicon-qrcode"></span> QR
+                </a>
+                <a id="download-btn" href="{{ url_for('bepasty.download', name=name) }}" class="btn btn-info">
+                    <span class="glyphicon glyphicon-download-alt"></span> Download
+                </a>
+                <a id="inline-btn" href="{{ url_for('bepasty.inline', name=name) }}" class="btn btn-info">
+                    <span class="glyphicon glyphicon-asterisk"></span> Inline
+                </a>
             {% endif %}
             {% if may(DELETE) %}
                 <form id="del-frm" action="{{ url_for('bepasty.delete', name=name) }}" method="post" class="btn-group">


### PR DESCRIPTION
For example, user can't copy link for "display" button in list
view. To allow to copy link, this changes <form> for GET to simple
link.