### PR TITLE
Use bootstrap for QR page

### DIFF
--- a/src/bepasty/templates/qr.html
+++ b/src/bepasty/templates/qr.html
@@ -1,5 +1,6 @@
-<html>
-<head>
+{% extends "_layout.html" %}
+
+{% block extra_link %}
 <script src="{{ url_for('static', filename='app/js/qrcode.js') }}" type="text/javascript"></script>
 
 <script>
@@ -66,39 +67,45 @@ function loaded() {
 
 window.addEventListener("load", loaded, false);
 </script>
+{% endblock %}
 
-<style>
-    html {
-      padding: 10px;
-      background: #FFF;
-    }
 
-    .label {
-      padding: 0 0 0 20px;
-    }
+{% block content %}
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <from class="form-horizontal">
+      <div class="form-group">
+	<label class="control-label col-sm-3" for="text">Content:</label>
+	<div class="col-sm-9">
+	  <input class="form-control" id="text" placeholder="https://example.org/" size="80" value="{{ text }}">
+	</div>
+      </div>
+      <div class="form-group row">
+	<label class="control-label col-sm-3" for="errorCorrectionLevel">Error correction:</label>
+	<div class="col-sm-2">
+	  <select class="form-control" id="errorCorrectionLevel" name="e">
+	    <option value="L">7% (L)</option>
+	    <option value="M">15% (M)</option>
+	    <option value="Q">25% (Q)</option>
+	    <option value="H" selected="selected">30% (H)</option>
+	  </select>
+	</div>
+	<label class="control-label col-sm-1" for="qrsize">Size:</label>
+	<div class="col-sm-6">
+	  <input type="range" class="form-control" id="qrsize" min="45" max="500" value="100">
+	</div>
+      </div>
+    </from>
 
-    #qr {
-      padding: 10px;
-      text-align: center;
-    }
-</style>
-</head>
-
-<body>
-    <div class="block">
-        <span class="label">Content:</span>
-        <input id="text" size="80" value="{{ text }}">
-        <span class="label">Error correction:</span>
-        <select id="errorCorrectionLevel" name="e">
-            <option value="L">7% (L)</option>
-            <option value="M">15% (M)</option>
-            <option value="Q">25% (Q)</option>
-            <option value="H" selected="selected">30% (H)</option>
-        </select>
-        <span class="label">Size:</span>
-        <input type="range" id="qrsize" min="45" max="500" value="100">
-        <input type="button" value="update" onclick="update()"/>
-        <div id="qr"></div>
+    <div class="text-right">
+      <button type="button" class="btn btn-primary" onclick="update()">Update</button>
     </div>
-</body>
-</html>
+  </div>
+
+  <div class="panel-body">
+    <div class="text-center">
+      <div id="qr"></div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
To consistent with other pages, this change QR page to use bootstrap,
and use a same template with display view.

With this change, QR page now has a navigation bar at top like other
pages, and uses better layout, by bootstrap, for several screen size.

[This might be better to use "modal" component of bootstrap in display
view.]

The following is screenshot of result of this change,

![qr-page](https://user-images.githubusercontent.com/1249571/97104625-bd62c780-16f8-11eb-87ec-38d82f092c12.png)
