### PR TITLE
Add delete/lock/unlock REST api

### DIFF
--- a/src/bepasty/apis/__init__.py
+++ b/src/bepasty/apis/__init__.py
@@ -1,7 +1,8 @@
 from flask import Blueprint
 
 from .lodgeit import LodgeitUpload
-from .rest import ItemDetailView, ItemDownloadView, ItemUploadView, InfoView
+from .rest import ItemDetailView, ItemDownloadView, ItemUploadView, InfoView, \
+    ItemDeleteView, ItemLockView, ItemUnlockView
 
 
 blueprint = Blueprint('bepasty_apis', __name__, url_prefix='/apis')
@@ -11,3 +12,6 @@ blueprint.add_url_rule('/rest', view_func=InfoView.as_view('api_info'))
 blueprint.add_url_rule('/rest/items', view_func=ItemUploadView.as_view('items'))
 blueprint.add_url_rule('/rest/items/<itemname:name>', view_func=ItemDetailView.as_view('items_detail'))
 blueprint.add_url_rule('/rest/items/<itemname:name>/download', view_func=ItemDownloadView.as_view('items_download'))
+blueprint.add_url_rule('/rest/items/<itemname:name>/delete', view_func=ItemDeleteView.as_view('items_delete'))
+blueprint.add_url_rule('/rest/items/<itemname:name>/lock', view_func=ItemLockView.as_view('items_lock'))
+blueprint.add_url_rule('/rest/items/<itemname:name>/unlock', view_func=ItemUnlockView.as_view('items_unlock'))

--- a/src/bepasty/apis/rest.py
+++ b/src/bepasty/apis/rest.py
@@ -15,7 +15,9 @@ from ..utils.name import ItemName
 from ..utils.permissions import CREATE, LIST, may
 from ..utils.upload import Upload, background_compute_hash
 from ..views.filelist import file_infos
+from ..views.delete import DeleteView
 from ..views.download import DownloadView
+from ..views.setkv import LockView, UnlockView
 
 
 # This wrappper handles exceptions in the REST api implementation.
@@ -237,6 +239,42 @@ class ItemDownloadView(ItemDetailView):
     @rest_errorhandler
     def get(self, name):
         return super(ItemDetailView, self).get(name)
+
+
+class ItemDeleteView(DeleteView, RestBase):
+    def error(self, item, error):
+        raise Conflict(description=error)
+
+    def response(self, name):
+        return make_response('{}', {'Content-Type': 'application/json'})
+
+    @rest_errorhandler
+    def post(self, name):
+        return super(ItemDeleteView, self).post(name)
+
+
+class ItemLockView(LockView, RestBase):
+    def error(self, item, error):
+        raise Conflict(description=error)
+
+    def response(self, name):
+        return make_response('{}', {'Content-Type': 'application/json'})
+
+    @rest_errorhandler
+    def post(self, name):
+        return super(ItemLockView, self).post(name)
+
+
+class ItemUnlockView(UnlockView, RestBase):
+    def error(self, item, error):
+        raise Conflict(description=error)
+
+    def response(self, name):
+        return make_response('{}', {'Content-Type': 'application/json'})
+
+    @rest_errorhandler
+    def post(self, name):
+        return super(ItemUnlockView, self).post(name)
 
 
 class InfoView(RestBase):

--- a/src/bepasty/views/delete.py
+++ b/src/bepasty/views/delete.py
@@ -10,6 +10,12 @@ from ..utils.permissions import ADMIN, DELETE, may
 
 
 class DeleteView(MethodView):
+    def error(self, item, error):
+        return render_template('error.html', heading=item.meta[FILENAME], body=error), 409
+
+    def response(self, name):
+        return redirect_next_referrer('bepasty.index')
+
     def post(self, name):
         if not may(DELETE):
             raise Forbidden()
@@ -17,7 +23,7 @@ class DeleteView(MethodView):
             with current_app.storage.open(name) as item:
                 if not item.meta[COMPLETE] and not may(ADMIN):
                     error = 'Upload incomplete. Try again later.'
-                    return render_template('error.html', heading=item.meta[FILENAME], body=error), 409
+                    self.error(item, error)
 
                 if item.meta[LOCKED] and not may(ADMIN):
                     raise Forbidden()
@@ -29,4 +35,4 @@ class DeleteView(MethodView):
                 raise NotFound()
             raise
 
-        return redirect_next_referrer('bepasty.index')
+        return self.response(name)

--- a/src/bepasty/views/setkv.py
+++ b/src/bepasty/views/setkv.py
@@ -19,6 +19,12 @@ class SetKeyValueView(MethodView):
     KEY = None
     NEXT_VALUE = None
 
+    def error(self, item, error):
+        return render_template('error.html', heading=item.meta[FILENAME], body=error), 409
+
+    def response(self, name):
+        return redirect_next_referrer('bepasty.display', name=name)
+
     def post(self, name):
         if self.REQUIRED_PERMISSION is not None and not may(self.REQUIRED_PERMISSION):
             raise Forbidden()
@@ -31,9 +37,9 @@ class SetKeyValueView(MethodView):
                 else:
                     error = None
                 if error:
-                    return render_template('error.html', heading=item.meta[FILENAME], body=error), 409
+                    return self.error(item, error)
                 item.meta[self.KEY] = self.NEXT_VALUE
-            return redirect_next_referrer('bepasty.display', name=name)
+            return self.response(name)
 
         except (OSError, IOError) as e:
             if e.errno == errno.ENOENT:


### PR DESCRIPTION
This adds the following new REST api,

	/apis/rest/<item>/delete - for delete
	/apis/rest/<item>/lock   - for lock
	/apis/rest/<item>/unlock - for unlock

With this, client can do those easier without web form.


the following bepasty.txt (github doesn't support to attach .py or no ext) is a client what im now using. it supports text/x-bepasty-list as like directory and recursive upload/download etc., and using all REST apis include new apis in this PR.

im not sure, this client should go where - bepasty-server, bepasty-client-cli, or dont public

[bepasty.txt](https://github.com/bepasty/bepasty-server/files/5479329/bepasty.txt)
