### PR TITLE
Use font-awesome everywhere

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'XStatic-asciinema-player',
         'xstatic-bootbox',
         'xstatic-bootstrap<4.0.0.0',
+        'xstatic-font-awesome',
         'xstatic-jquery',
         'xstatic-jquery-ui',
         'xstatic-jquery-file-upload',

--- a/src/bepasty/bepasty_xstatic.py
+++ b/src/bepasty/bepasty_xstatic.py
@@ -5,6 +5,7 @@ mod_names = [
     'asciinema_player',
     'bootbox',
     'bootstrap',
+    'font_awesome',
     'jquery',
     'jquery_ui',
     'jquery_file_upload',

--- a/src/bepasty/static/app/css/style.css
+++ b/src/bepasty/static/app/css/style.css
@@ -56,7 +56,7 @@ body {
     padding: 0 15px 60px;
 }
 
-.jumbotron .glyphicon {
+.jumbotron .fa {
     font-size: 80px;
 }
 

--- a/src/bepasty/templates/_layout.html
+++ b/src/bepasty/templates/_layout.html
@@ -15,7 +15,7 @@
         <!-- jQuery UI styles -->
         <link rel="stylesheet" href="{{ url_for('bepasty.xstatic', name='jquery_ui', filename='themes/smoothness/jquery-ui.css') }}" type="text/css">
         <!-- Font Awesome -->
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="{{ url_for('bepasty.xstatic', name='font_awesome', filename='css/font-awesome.min.css') }}">
         <!-- Bepasty styles -->
         <link rel="stylesheet" href="{{ url_for('static', filename='app/css/style.css' ) }}" type="text/css">
         {% block extra_link %}{% endblock %}

--- a/src/bepasty/templates/display.html
+++ b/src/bepasty/templates/display.html
@@ -9,20 +9,20 @@
         <div class="btn-group">
             {% if not item.meta['locked'] or may(ADMIN) %}
                 <a id="qr-btn" href="{{ url_for('bepasty.qr', name=name) }}" class="btn btn-info">
-                    <span class="glyphicon glyphicon-qrcode"></span> QR
+                    <span class="fa fa-qrcode"></span> QR
                 </a>
                 <a id="download-btn" href="{{ url_for('bepasty.download', name=name) }}" class="btn btn-info">
-                    <span class="glyphicon glyphicon-download-alt"></span> Download
+                    <span class="fa fa-download"></span> Download
                 </a>
                 <a id="inline-btn" href="{{ url_for('bepasty.inline', name=name) }}" class="btn btn-info">
-                    <span class="glyphicon glyphicon-asterisk"></span> Inline
+                    <span class="fa fa-asterisk"></span> Inline
                 </a>
             {% endif %}
             {% if may(DELETE) %}
                 <form id="del-frm" action="{{ url_for('bepasty.delete', name=name) }}" method="post" class="btn-group">
                     <input type="hidden" name="next" value="{{ url_for('bepasty.index') }}">
                     <button id="del-btn" type="button" class="btn btn-danger">
-                        <span class="glyphicon glyphicon-remove"></span> Delete
+                        <span class="fa fa-remove"></span> Delete
                     </button>
                 </form>
             {% endif %}
@@ -30,13 +30,13 @@
             {% if not item.meta['locked'] %}
                 <form id="lock-frm" action="{{ url_for('bepasty.lock', name=name) }}" method="post" class="btn-group">
                     <button id="lock-btn" type="submit" class="btn btn-danger">
-                        <span class="glyphicon glyphicon-lock"></span> Lock
+                        <span class="fa fa-lock"></span> Lock
                     </button>
                 </form>
             {% else %}
                 <form id="unlock-frm" action="{{ url_for('bepasty.unlock', name=name) }}" method="post" class="btn-group">
                     <button id="unlock-btn" type="submit" class="btn btn-info">
-                        <span class="glyphicon glyphicon-heart"></span> Unlock
+                        <span class="fa fa-unlock"></span> Unlock
                     </button>
                 </form>
             {% endif %}

--- a/src/bepasty/templates/index.html
+++ b/src/bepasty/templates/index.html
@@ -2,79 +2,79 @@
 
 {% macro maximum_lifetime() -%}
 <div class="row">
-  <div class="col-md-3 form-group">
-    <input class="form-control" name="maxlife-value" type="number" min="1" value="1" /><br>
-  </div>
-  <div class="col-md-9 form-group">
-    <select class="form-control" name="maxlife-unit" size="1">
-      <option value="months">Months</option>
-      <option value="weeks">Weeks</option>
-      <option value="days">Days</option>
-      <option value="hours">Hours</option>
-      <option value="minutes">Minutes</option>
-      <option value="years">Years</option>
-      <option value="forever">Keep Forever</option>
-    </select>
-  </div>
+    <div class="col-md-3 form-group">
+        <input class="form-control" name="maxlife-value" type="number" min="1" value="1" /><br>
+    </div>
+    <div class="col-md-9 form-group">
+        <select class="form-control" name="maxlife-unit" size="1">
+            <option value="months">Months</option>
+            <option value="weeks">Weeks</option>
+            <option value="days">Days</option>
+            <option value="hours">Hours</option>
+            <option value="minutes">Minutes</option>
+            <option value="years">Years</option>
+            <option value="forever">Keep Forever</option>
+        </select>
+    </div>
 </div>
 {% endmacro %}
 
 {% block content %}
 {% if may(CREATE) %}
 <div class="row">
-  <div class="col-sm-8">
-    <form action="{{ url_for('bepasty.upload') }}" method="POST" enctype="multipart/form-data">
-      <div class="form-group">
-        <textarea class="form-control" id="formupload" name="text" placeholder="Paste text here..." autofocus></textarea>
-      </div>
-      <div class="row">
-        <div class="col-xs-3 form-group">
-          <input class="form-control" type="text" id="contenttype" name="contenttype" size="30" placeholder="Content-Type">
-        </div>
-        <div class="col-xs-6 form-group">
-          <input class="form-control" type="text" id="filename" name="filename" size="40" placeholder="optional download-filename">
-        </div>
-        <div class="col-xs-3">
-          <button id="formupload-submit" class="btn btn-success btn-block">Submit</button>
-        </div>
-      </div>
-      <hr>
-      <label>Maximum lifetime value (choose before dragging or submitting)</label>
-      {{ maximum_lifetime() }}
-      <span class="btn btn-default fileinput-button dropzone">
-        <i class="fa fa-upload"></i>
-        <span>drag and drop files here - or click to select files</span>
-        <!-- Input for file upload widget -->
-        <input id="fileupload" type="file" name="file" multiple style="height: 100%; width: 100%;">
-      </span>
-      <noscript><br><button id="fileupload-submit" class="btn btn-success btn-block">Upload</button></noscript>
-    </form>
-  </div>
-  <div class="col-sm-4">
-    <!-- item name list assembled here and offered for submission -->
-    <form id="filelist-form" style="display: none" action="{{ url_for('bepasty.upload') }}" method="POST" enctype="multipart/form-data">
-      <div class="form-group">
-        <textarea class="form-control" id="filelist" name="text" rows="10" cols="40"></textarea>
-      </div>
-      {{ maximum_lifetime() }}
-      <input type="hidden" name="contenttype" value="text/x-bepasty-list">
-      <div class="row">
-        <div class="col-md-7 form-group">
-          <input class="form-control" type="text" id="filelist-filename" name="filename" size="23" placeholder="optional list-name">
-        </div>
-        <div class="col-md-5">
-          <button class="btn btn-success btn-block">Create List Item</button>
-        </div>
-      </div>
-    </form>
-    <button id="fileupload-abort" class="btn btn-danger pull-right" style="visibility: hidden">abort</button>
-    <!-- The progress bar -->
-    <div id="fileupload-progress" class="progress progress-striped active" style="visibility: hidden">
-      <div class="progress-bar"></div>
+    <div class="col-sm-8">
+        <form action="{{ url_for('bepasty.upload') }}" method="POST" enctype="multipart/form-data">
+            <div class="form-group">
+                <textarea class="form-control" id="formupload" name="text" placeholder="Paste text here..." autofocus></textarea>
+            </div>
+            <div class="row">
+                <div class="col-xs-3 form-group">
+                    <input class="form-control" type="text" id="contenttype" name="contenttype" size="30" placeholder="Content-Type">
+                </div>
+                <div class="col-xs-6 form-group">
+                    <input class="form-control" type="text" id="filename" name="filename" size="40" placeholder="optional download-filename">
+                </div>
+                <div class="col-xs-3">
+                    <button id="formupload-submit" class="btn btn-success btn-block">Submit</button>
+                </div>
+            </div>
+            <hr>
+            <label>Maximum lifetime value (choose before dragging or submitting)</label>
+            {{ maximum_lifetime() }}
+            <span class="btn btn-default fileinput-button dropzone">
+                <i class="fa fa-upload"></i>
+                <span>drag and drop files here - or click to select files</span>
+                <!-- Input for file upload widget -->
+                <input id="fileupload" type="file" name="file" multiple style="height: 100%; width: 100%;">
+            </span>
+            <noscript><br><button id="fileupload-submit" class="btn btn-success btn-block">Upload</button></noscript>
+        </form>
     </div>
-    <!-- Uploaded files -->
-    <div id="files" class="files"></div>
-  </div>
+    <div class="col-sm-4">
+        <!-- item name list assembled here and offered for submission -->
+        <form id="filelist-form" style="display: none" action="{{ url_for('bepasty.upload') }}" method="POST" enctype="multipart/form-data">
+            <div class="form-group">
+                <textarea class="form-control" id="filelist" name="text" rows="10" cols="40"></textarea>
+            </div>
+            {{ maximum_lifetime() }}
+            <input type="hidden" name="contenttype" value="text/x-bepasty-list">
+            <div class="row">
+                <div class="col-md-7 form-group">
+                    <input class="form-control" type="text" id="filelist-filename" name="filename" size="23" placeholder="optional list-name">
+                </div>
+                <div class="col-md-5">
+                    <button class="btn btn-success btn-block">Create List Item</button>
+                </div>
+            </div>
+        </form>
+        <button id="fileupload-abort" class="btn btn-danger pull-right" style="visibility: hidden">abort</button>
+        <!-- The progress bar -->
+        <div id="fileupload-progress" class="progress progress-striped active" style="visibility: hidden">
+            <div class="progress-bar"></div>
+        </div>
+        <!-- Uploaded files -->
+        <div id="files" class="files"></div>
+    </div>
 </div>
 
 {% else %}
@@ -134,16 +134,16 @@
 <script src="{{ url_for('bepasty.xstatic', name='bootbox', filename='bootbox.min.js') }}" type="text/javascript"></script>
 <!-- fileuploader -->
 <script type="application/javascript">
-MAX_ALLOWED_FILE_SIZE = {{ config.MAX_ALLOWED_FILE_SIZE }};
-MAX_BODY_SIZE = {{ config.MAX_BODY_SIZE }};
-UPLOAD_NEW_URL = "{{ url_for('bepasty.upload_new') }}";
+    MAX_ALLOWED_FILE_SIZE = {{ config.MAX_ALLOWED_FILE_SIZE }};
+    MAX_BODY_SIZE = {{ config.MAX_BODY_SIZE }};
+    UPLOAD_NEW_URL = "{{ url_for('bepasty.upload_new') }}";
 </script>
 <script src="{{ url_for('static', filename='app/js/fileuploader.js') }}" type="text/javascript"></script>
 
 <script>
-$(function() {
-    var availableTypes = ["{{ contenttypes | join('","') | safe}}"];
-    $("#contenttype").autocomplete({source: availableTypes});
-});
+    $(function() {
+        var availableTypes = ["{{ contenttypes | join('","') | safe}}"];
+        $("#contenttype").autocomplete({source: availableTypes});
+    });
 </script>
 {% endblock %}

--- a/src/bepasty/templates/index.html
+++ b/src/bepasty/templates/index.html
@@ -42,7 +42,7 @@
       <label>Maximum lifetime value (choose before dragging or submitting)</label>
       {{ maximum_lifetime() }}
       <span class="btn btn-default fileinput-button dropzone">
-        <i class="glyphicon glyphicon-upload"></i>
+        <i class="fa fa-upload"></i>
         <span>drag and drop files here - or click to select files</span>
         <!-- Input for file upload widget -->
         <input id="fileupload" type="file" name="file" multiple style="height: 100%; width: 100%;">
@@ -84,7 +84,7 @@
 <div class="jumbotron">
     <div class="row">
         <div class="col-sm-3">
-            <span class="glyphicon glyphicon-thumbs-up"></span>
+            <span class="fa fa-thumbs-o-up"></span>
             <h2>Free and Nice</h2>
             <p>
                 A pastebin for <em>all</em> the stuff,<br>
@@ -92,7 +92,7 @@
             </p>
         </div>
         <div class="col-sm-6">
-            <span class="glyphicon glyphicon-eye-open"></span>
+            <span class="fa fa-eye"></span>
             <h2>Free and Open Source</h2>
             <p>
                 bepasty is free and open source software.<br>
@@ -100,7 +100,7 @@
             </p>
         </div>
         <div class="col-sm-3">
-            <span class="glyphicon glyphicon-heart-empty"></span>
+            <span class="fa fa-heart-o"></span>
             <h2>Awesome Code</h2>
             <p>
                 Powered by <a href="http://python.org">Python</a> and


### PR DESCRIPTION
Now, using 2 font families of font-awesome and font-glyphicon. And
bootstrap4 stopped to include font-glyphicon, so this uses
font-awesome everywhere.

To do it,

- add dependency to xstatic-font-awesome, instead of fetching from internet.
- replace icon in font-glyphicon to similar icon in font-awesome
  [glyphicon-heart is replaced with fa-unlock, because font-awesome
   has real unlock icon.]

With this changes, user doesn't need to download 2 fonts, and prepare
for bootstrap4.