### PR TITLE
Add optional python-magic support for application/octet-stream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,11 @@ setup(
         'xstatic-jquery-file-upload',
         'xstatic-pygments',
     ],
+    extras_require={
+        "magic": [
+            'python-magic'
+        ],
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/src/bepasty/apis/rest.py
+++ b/src/bepasty/apis/rest.py
@@ -13,7 +13,7 @@ from ..utils.date_funcs import get_maxlife
 from ..utils.http import ContentRange, DownloadRange
 from ..utils.name import ItemName
 from ..utils.permissions import CREATE, LIST, may
-from ..utils.upload import Upload, background_compute_hash
+from ..utils.upload import Upload, filter_internal, background_compute_hash
 from ..views.filelist import file_infos
 from ..views.delete import DeleteView
 from ..views.download import DownloadView
@@ -204,7 +204,7 @@ class ItemUploadView(RestBase):
         for meta in file_infos():
             name = meta.pop(ID)
             ret[name] = {'uri': url_for('bepasty_apis.items_detail', name=name),
-                         'file-meta': meta}
+                         'file-meta': filter_internal(meta)}
         return jsonify(ret)
 
 
@@ -214,7 +214,7 @@ class ItemDetailView(DownloadView, RestBase):
 
     def response(self, item, name):
         return jsonify({'uri': url_for('bepasty_apis.items_detail', name=name),
-                        'file-meta': dict(item.meta)})
+                        'file-meta': filter_internal(item.meta)})
 
     @rest_errorhandler
     def get(self, name):

--- a/src/bepasty/config.py
+++ b/src/bepasty/config.py
@@ -70,6 +70,14 @@ class Config(object):
         '': 1 * 1000 * 1000,
     }
 
+    # Whether to use the python-magic module to guess a file's mime
+    # type by looking into its content (if the mime type can not be
+    # determined from the filename extension).
+    # NOTE:
+    # libmagic may have security issues, so maybe you should only use
+    # it if you trust all users with upload permissions ('create').
+    USE_PYTHON_MAGIC = False
+
     #: Define storage backend, choose from:
     #:
     #: - 'filesystem'

--- a/src/bepasty/constants.py
+++ b/src/bepasty/constants.py
@@ -1,5 +1,6 @@
 FILENAME = 'filename'
 TYPE = 'type'
+TYPE_HINT = 'type-hint'
 LOCKED = 'locked'
 SIZE = 'size'
 COMPLETE = 'complete'
@@ -12,3 +13,6 @@ FOREVER = -1
 
 # headers
 TRANSACTION_ID = 'Transaction-ID'  # keep in sync with bepasty-cli
+
+# used internally only
+internal_meta = [TYPE_HINT]

--- a/src/bepasty/tests/test_rest_server.py
+++ b/src/bepasty/tests/test_rest_server.py
@@ -897,6 +897,7 @@ def test_incomplete(client_fixture):
     response = _upload(client, data, token='full', filename=filename,
                        ftype=ftype, range_str=range_str)
     check_upload_response(response, 200)
+    assert len(response.headers[TRANSACTION_ID]) > 0
 
     # get incomplete item from list
     url = RestUrl()
@@ -932,3 +933,61 @@ def test_incomplete(client_fixture):
     # delete by admin with incomplete should succeed
     response = client.post(url.delete, headers=add_auth('user', 'admin'))
     check_json_response(response, {})
+
+
+def test_magic(client_fixture):
+    app, client, _ = client_fixture
+
+    try:
+        import magic
+        assert magic is not None  # suppress flake8 warning
+    except ImportError:
+        pytest.skip("skipping test, no python-magic installed")
+    else:
+        with TmpConfig(app, {'USE_PYTHON_MAGIC': True}):
+            filename = None
+            ftype = None
+
+            # upload a half of data to make incomplete with auto mime
+            # detection (meta has 'type-hint' internally)
+            sep = 10
+            data = UPLOAD_DATA[:sep]
+            range_str = 'bytes {}-{}/{}'.format(0, sep - 1, len(UPLOAD_DATA))
+            response = _upload(client, data, token='full', filename=filename,
+                               ftype=ftype, range_str=range_str)
+            check_upload_response(response, 200)
+            assert len(response.headers[TRANSACTION_ID]) > 0
+            trans_id = response.headers[TRANSACTION_ID]
+
+            # get incomplete item from list
+            url = RestUrl()
+            headers = add_auth('user', 'full')
+            response = client.get(url.list, headers=headers)
+            check_response(response, 200)
+            assert len(response.json) == 1
+
+            fid = list(response.json.keys())[0]
+            meta = list(response.json.values())[0]
+
+            # 'type-hint' should be invisible
+            assert meta['file-meta'] is not None
+            assert meta['file-meta'].get('type-hint') is None
+
+            # 'type' is 'application/octet-stream' for now
+            assert meta['file-meta'][TYPE] == 'application/octet-stream'
+
+            # complete upload
+            data = UPLOAD_DATA[sep:]
+            range_str = 'bytes {}-{}/{}'.format(sep, len(UPLOAD_DATA) - 1,
+                                                len(UPLOAD_DATA))
+            response = _upload(client, data, token='full', range_str=range_str,
+                               trans_id=trans_id)
+            check_upload_response(response)
+
+            # get detail to check python-magic auto detection
+            url = RestUrl(fid)
+            response = client.get(url.detail, headers=add_auth('user', 'full'))
+            check_json_response(response, None, check_data=False)
+
+            assert response.json['file-meta'] is not None
+            assert response.json['file-meta'][TYPE] == 'text/x-python'

--- a/src/bepasty/utils/upload.py
+++ b/src/bepasty/utils/upload.py
@@ -5,6 +5,14 @@ from werkzeug.exceptions import BadRequest, RequestEntityTooLarge
 
 from flask import current_app
 
+try:
+    import magic as magic_module
+    magic = magic_module.Magic(mime=True)
+    magic_bufsz = magic.getparam(magic_module.MAGIC_PARAM_BYTES_MAX)
+except ImportError:
+    magic = None
+    magic_bufsz = None
+
 from ..constants import (
     COMPLETE,
     FILENAME,
@@ -16,6 +24,8 @@ from ..constants import (
     TIMESTAMP_MAX_LIFE,
     TIMESTAMP_UPLOAD,
     TYPE,
+    TYPE_HINT,
+    internal_meta,
 )
 from .name import ItemName
 from .decorators import threaded
@@ -68,12 +78,18 @@ class Upload(object):
         """
         Filter Content-Type
         Only allow some basic characters and shorten to 50 characters.
+
+        Return value:
+        tuple[0] - content-type string
+        tuple[1] - whether tuple[0] is hint or not
+                   True:  content-type is just a hint
+                   False: content-type is not a hint, was specified by user
         """
         if not ct and filename:
             ct, encoding = mimetypes.guess_type(filename)
         if not ct:
-            return ct_hint
-        return cls._type_re.sub('', ct)[:50]
+            return ct_hint, True
+        return cls._type_re.sub('', ct)[:50], False
 
     @classmethod
     def meta_new(cls, item, input_size, input_filename, input_type,
@@ -82,7 +98,9 @@ class Upload(object):
             input_filename, storage_name, input_type, input_type_hint
         )
         item.meta[SIZE] = cls.filter_size(input_size)
-        item.meta[TYPE] = cls.filter_type(input_type, input_type_hint, input_filename)
+        ct, hint = cls.filter_type(input_type, input_type_hint, input_filename)
+        item.meta[TYPE] = ct
+        item.meta[TYPE_HINT] = hint
         item.meta[TIMESTAMP_UPLOAD] = int(time.time())
         item.meta[TIMESTAMP_DOWNLOAD] = 0
         item.meta[LOCKED] = current_app.config['UPLOAD_LOCKED']
@@ -92,6 +110,11 @@ class Upload(object):
 
     @classmethod
     def meta_complete(cls, item, file_hash):
+        # update TYPE by python-magic if not decided yet
+        if item.meta.pop(TYPE_HINT, False):
+            if magic and current_app.config.get('USE_PYTHON_MAGIC', False):
+                if item.meta[TYPE] == 'application/octet-stream':
+                    item.meta[TYPE] = magic.from_buffer(item.data.read(magic_bufsz, 0))
         item.meta[COMPLETE] = True
         item.meta[HASH] = file_hash
 
@@ -136,6 +159,13 @@ def create_item(f, filename, size, content_type, content_type_hint,
                         name, maxlife_stamp=maxlife_stamp)
         Upload.meta_complete(item, file_hash)
     return name
+
+
+def filter_internal(meta):
+    """
+    filter internal meta data out.
+    """
+    return {k: v for k, v in meta.items() if k not in internal_meta}
 
 
 @threaded


### PR DESCRIPTION
This uses python-magic to improve mime type auto detection if user
didn't specify and filename couldn't detect.

To do it, make internal only metadata by "internal_meta[]". Then add
TYPE_HINT as internal metadata to remember to tell the pending state
of auto detection until file data is available.

[I'm not sure if there is better way to do this than internal_meta[] or not.]