### PR TITLE
Disallow the old cookie for PERMISSIONS in old config

### DIFF
--- a/src/bepasty/app.py
+++ b/src/bepasty/app.py
@@ -1,5 +1,6 @@
 import os
 import time
+import hashlib
 
 from flask import (
     Flask,
@@ -45,12 +46,33 @@ class PrefixMiddleware(object):
             return ['This URL does not belong to the bepasty app.'.encode()]
 
 
+def setup_secret_key(app):
+    """
+    The secret key is used to sign cookies and cookies not signed with the
+    current secret key are considered invalid.
+
+    Here, we amend the configured secret key, so it depends on some
+    other config values. Changing any of these values will change the
+    computed secret key (and thus invalidate all previously made
+    cookies).
+
+    Currently supported secret-changing config values: PERMISSIONS
+    """
+    # if app.config['SECRET_KEY'] is empty, keep as NullSession
+    if app.config['SECRET_KEY']:
+        perms = sorted(k + v for k, v in app.config['PERMISSIONS'].items())
+        perms = ''.join(perms).encode()
+        app.config['SECRET_KEY'] += hashlib.sha256(perms).hexdigest()
+
+
 def create_app():
     app = Flask(__name__)
 
     app.config.from_object('bepasty.config.Config')
     if os.environ.get('BEPASTY_CONFIG'):
         app.config.from_envvar('BEPASTY_CONFIG')
+
+    setup_secret_key(app)
 
     prefix = app.config.get('APP_BASE_PATH')
     if prefix is not None:

--- a/src/bepasty/tests/test_app.py
+++ b/src/bepasty/tests/test_app.py
@@ -1,0 +1,26 @@
+#
+# app tests
+#
+
+from ..app import create_app
+from ..config import Config
+
+
+def test_secret_key():
+    Config.PERMISSIONS = {
+        'admin': 'admin,list,create,read,delete',
+        'full': 'list,create,read,delete',
+        'none': '',
+    }
+    Config.SECRET_KEY = 'secret'
+
+    app = create_app()
+    secret_key = app.config['SECRET_KEY']
+    assert len(secret_key) > len(Config.SECRET_KEY)
+
+    Config.PERMISSIONS = {
+        'admin': 'admin,list,create,read,delete',
+        'none': '',
+    }
+    app = create_app()
+    assert app.config['SECRET_KEY'] != secret_key


### PR DESCRIPTION
This changes the content of session cookie from PERMISSIONS string to
password.

Because, without this change, even if PERMISSIONS in server config was
changed, PERMISSIONS in cookie are still used until the cookie is
removed from client side.

Also possibly more secure even if SECRET_KEY was leaked? Because user
can't add PERMISSIONS by modifying the cookie.