### PR TITLE
add +thumbnail view, fixes #177

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ setup(
         "magic": [
             'python-magic',
         ],
+        "pillow": [
+            'Pillow',
+        ],
     },
     python_requires=">=3.6",
     classifiers=[

--- a/src/bepasty/templates/_utils.html
+++ b/src/bepasty/templates/_utils.html
@@ -2,13 +2,15 @@
     <table class="table table-hover">
         <thead>
         <tr>
-            <th>
+            <th class="text-right">
                 Filename
                 <br />
                 Type
-            </th>
-            <th class="text-right">
+                <br />
                 Size [B]
+            </th>
+            <th>
+                Thumbnail
             </th>
             <th>
                 Upload [UTC]
@@ -23,13 +25,19 @@
         <tbody>
             {% for file in files %}
             <tr>
-                <td>
-                    <a href="{{ url_for('bepasty.display', name=file['id']) }}">{{ file['filename'] }}</a>
+                <td class="text-right">
+                    <a href="{{ url_for('bepasty.display', name=file['id']) }}">
+                        {{ file['filename'] }}
+                    </a>
                     <br />
                     {{ file['type'] }}
-                </td>
-                <td class="text-right">
+                    <br />
                     {{ file['size'] }}
+                </td>
+                <td>
+                    <a href="{{ url_for('bepasty.display', name=file['id']) }}">
+                        <img src="{{ url_for('bepasty.thumbnail', name=file['id']) }}">
+                    </a>
                 </td>
                 <td>
                     {{ file['timestamp-upload'] | datetime }}

--- a/src/bepasty/views/__init__.py
+++ b/src/bepasty/views/__init__.py
@@ -2,7 +2,7 @@ from flask import Blueprint
 
 from .delete import DeleteView
 from .display import DisplayView
-from .download import DownloadView, InlineView
+from .download import DownloadView, InlineView, ThumbnailView
 from .modify import ModifyView
 from .qr import QRView
 from .filelist import FileListView
@@ -25,6 +25,7 @@ blueprint.add_url_rule('/<itemname:name>', view_func=DisplayView.as_view('displa
 blueprint.add_url_rule('/<itemname:name>/+delete', view_func=DeleteView.as_view('delete'))
 blueprint.add_url_rule('/<itemname:name>/+download', view_func=DownloadView.as_view('download'))
 blueprint.add_url_rule('/<itemname:name>/+inline', view_func=InlineView.as_view('inline'))
+blueprint.add_url_rule('/<itemname:name>/+thumbnail', view_func=ThumbnailView.as_view('thumbnail'))
 blueprint.add_url_rule('/<itemname:name>/+modify', view_func=ModifyView.as_view('modify'))
 blueprint.add_url_rule('/<itemname:name>/+qr', view_func=QRView.as_view('qr'))
 blueprint.add_url_rule('/<itemname:name>/+lock', view_func=LockView.as_view('lock'))

--- a/src/bepasty/views/download.py
+++ b/src/bepasty/views/download.py
@@ -87,6 +87,13 @@ class InlineView(DownloadView):
 class ThumbnailView(InlineView):
     thumbnail_size = 192, 108
     thumbnail_type = 'jpeg'  # png, jpeg
+    thumbnail_data = """\
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg width="108" height="108" viewBox="0 0 108 108" xmlns="http://www.w3.org/2000/svg">
+        <rect x="1" y="1" width="106" height="106" fill="whitesmoke" stroke-width="2" stroke="blue" />
+            <line x1="1" y1="1" x2="106" y2="106" stroke="blue" stroke-width="2" />
+            <line x1="1" y1="106" x2="106" y2="0" stroke="blue" stroke-width="2" />
+        </svg>""".strip().encode()
 
     def err_incomplete(self, item, error):
         return b'', 409  # conflict
@@ -100,7 +107,12 @@ class ThumbnailView(InlineView):
         fn = item.meta[FILENAME]
         ct = item.meta[TYPE]
         if not ct.startswith("image/"):
-            return b'', 405  # method not allowed
+            # return a placeholder thumbnail for unsupported item types
+            ret = Response(self.thumbnail_data)
+            ret.headers['Content-Length'] = len(self.thumbnail_data)
+            ret.headers['Content-Type'] = 'image/svg+xml'
+            ret.headers['X-Content-Type-Options'] = 'nosniff'  # yes, we really mean it
+            return ret
 
         # compute thumbnail data "on the fly"
         with BytesIO(item.data.read(sz, 0)) as img_bio, BytesIO() as thumbnail_bio:


### PR DESCRIPTION
same usage as +download or +inline, but dynamically computes a thumbnail in memory.

this function is not yet exposed on the UI, because it is intended to be used
by some future "image gallery" feature.

for thumbnail computation, Pillow (PIL fork) is used, which can be installed
as an extra, but optional requirement.