### PR TITLE
docs: REST POST response returns file URI in Content-Location

### DIFF
--- a/docs/source/rest.rst
+++ b/docs/source/rest.rst
@@ -142,7 +142,7 @@ POST Response by the server:
     *Transaction-ID*
         Transaction-ID provided for continued upload in a chunked upload
         process.
-    *Content-Disposition*
+    *Content-Location*
         The URI of the newly uploaded file on the server. Will only be
         provided when upload is finished and successful.
 


### PR DESCRIPTION
While working on a [CLI in ruby](https://github.com/aither64/bepasty-client), I've discovered that the docs mention file URI in REST API being returned in `Content-Disposition`, while actually it is returned in `Content-Location`.

I'd also like to ask if you're ok with me naming the CLI bepasty-client? Would you merge a PR adding it to `docs/source/user-cli.rst`? I found pastebinit outdated and annoying to work with, so I've implemented something for my own purposes.