### PR TITLE
Fallback to Chrom(e|ium) if the Firefox driver for selenium isn't available

### DIFF
--- a/src/bepasty/tests/test_website.py
+++ b/src/bepasty/tests/test_website.py
@@ -1,6 +1,10 @@
 from selenium.webdriver import Firefox
+from selenium.webdriver.chrome.service import Service as ChromeService
+from selenium.webdriver import Chrome
 from selenium.webdriver.common.keys import Keys
-from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import (
+    NoSuchDriverException, NoSuchElementException
+)
 
 import pytest
 
@@ -17,7 +21,11 @@ class TestMaxlifeFeature:
         """
         Setup: Open a mozilla browser, login
         """
-        self.browser = Firefox()
+        try:
+            self.browser = Firefox()
+        except NoSuchDriverException:
+            service = ChromeService(executable_path="/usr/bin/chromedriver")
+            self.browser = Chrome(service=service)
         self.browser.get('http://localhost:5000/')
         token = self.browser.find_element_by_name("token")
         password = "foo"


### PR DESCRIPTION
Installing the selenium driver for Firefox under Debian is a bit of a pain, so when trying to run the tests locally I've found it easier to change the code to fallback to the Chromium driver if using the Firefox one fails.

As a Firefox user myself (for everything else) I would consider it extremely reasonable if this PR was refused, but I felt it was right to submit it in case it was useful for somebody else.